### PR TITLE
chore: update github token location

### DIFF
--- a/components/header/utils.js
+++ b/components/header/utils.js
@@ -12,7 +12,7 @@ export default async function getOpenIssues() {
 
   async function getSecret() {
     const [secret] = await client.accessSecretVersion({
-      name: "projects/ccv-status/secrets/myGithubToken/versions/latest",
+      name: "projects/ccv-website-next/secrets/myGithubToken/versions/latest",
     })
 
     return secret.payload.data.toString()


### PR DESCRIPTION
Previously had been using the same token as the ccv-status repo -- this saves our own PAT in this project's secret manager