### PR TITLE
feat: herocard formatting

### DIFF
--- a/components/HeroCard.tsx
+++ b/components/HeroCard.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import { Card, CardContent } from "@/components/ui/card";
+import React from "react"
+import { Card, CardContent } from "@/components/ui/card"
 
 const heroCards = [
   {
@@ -17,14 +17,17 @@ const heroCards = [
     description:
       "We maintain secure, high-performance computing infrastructure, along with storage solutions and virtual computing environments to support research and innovation.",
   },
-];
+]
 
 export const HeroCard: React.FC = () => {
   return (
-    <div className="relative z-10 flex justify-center mx-auto" style={{ marginTop: "-150px" }}>
-      <Card className="w-[1342px] bg-white rounded-[5px] shadow-[0px_4px_4px_1px_#0000001a] border-none">
+    <div
+      className="relative z-10 flex justify-center mx-auto"
+      style={{ marginTop: "-150px" }}
+    >
+      <Card className="inline-block bg-white rounded-[5px] shadow-[0px_4px_4px_1px_#0000001a] border-none">
         <CardContent className="p-10">
-          <div className="flex justify-center items-start gap-[88px]">
+          <div className="flex justify-center items-start gap-[88px] flex-wrap">
             {heroCards.map((card, index) => (
               <div key={index} className="w-[348px]">
                 <div className="inline-flex items-center gap-2 px-[5px] py-[29px]">
@@ -48,5 +51,5 @@ export const HeroCard: React.FC = () => {
         </CardContent>
       </Card>
     </div>
-  );
-};
+  )
+}

--- a/components/HeroCard.tsx
+++ b/components/HeroCard.tsx
@@ -24,7 +24,7 @@ export const HeroCard: React.FC = () => {
     <div className="relative z-10 mx-auto" style={{ marginTop: '-150px' }}>
       <Card className="w-[1342px] bg-white rounded-[5px] shadow-[0px_4px_4px_1px_#0000001a] border-none">
         <CardContent className="p-10">
-          <div className="flex items-center gap-[88px]">
+          <div className="flex justify-center items-start gap-[88px]">
             {heroCards.map((card, index) => (
               <div key={index} className="w-[348px]">
                 <div className="inline-flex items-center gap-2 px-[5px] py-[29px]">

--- a/components/HeroCard.tsx
+++ b/components/HeroCard.tsx
@@ -21,7 +21,7 @@ const heroCards = [
 
 export const HeroCard: React.FC = () => {
   return (
-    <div className="relative z-10 mx-auto" style={{ marginTop: '-150px' }}>
+    <div className="relative z-10 flex justify-center mx-auto" style={{ marginTop: "-150px" }}>
       <Card className="w-[1342px] bg-white rounded-[5px] shadow-[0px_4px_4px_1px_#0000001a] border-none">
         <CardContent className="p-10">
           <div className="flex justify-center items-start gap-[88px]">


### PR DESCRIPTION
I updated the hero card: 
* centered component on the page 
* vertically aligned inner cards
* added flex wrapping for the cards 
![Screenshot 2025-04-03 at 2 07 40 PM](https://github.com/user-attachments/assets/48354d75-6b42-4fb2-a09b-5fef81440dcb)



**Question:**
The linter removed all the semicolons that were once there. Is that standard for this project? I didn't configure anything...