### PR TITLE
Fix event section formatting

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -33,7 +33,7 @@
 /* Apply zoom on all screen sizes */
 @media {
   body {
-    zoom: 0.75;
+    zoom: 1;
   }
 }
 

--- a/components/EventSection.tsx
+++ b/components/EventSection.tsx
@@ -1,7 +1,7 @@
 // components/EventSection.tsx
 "use client"
 
-import { use, useState } from "react"
+import { JSX, Key, use, useState } from "react"
 import CalendarEvent from "@/components/calendar/CalendarEvent"
 import CalendarWeekly from "@/components/calendar/CalendarWeekly"
 import CalendarMonth from "@/components/calendar/CalendarMonth"
@@ -12,7 +12,14 @@ import { Button } from "@/components/ui/button"
 
 const events_url = "https://events.brown.edu/ccv/all"
 
-export interface DataProps { }
+export interface DataProps {
+  date_utc: string
+  date2_utc: string
+  date_iso: string
+  date_time: string
+  title: string
+  url: string
+}
 
 function classNames(...classes: (string | boolean | undefined)[]) {
   return classes.filter(Boolean).join(" ")
@@ -32,9 +39,11 @@ export function EventSection({
   currentDate,
 }: EventSectionProps): JSX.Element {
   const dataFuture = use(streamedDataFuture)
-  const dataPast   = use(streamedDataPast)
-  const [view, setView] = useState<"Upcoming"|"Weekly"|"Monthly">("Upcoming")
-  const CAL_VIEW_ARRAY = ["Upcoming","Weekly","Monthly"] as const
+  const dataPast = use(streamedDataPast)
+  const [view, setView] = useState<"Upcoming" | "Weekly" | "Monthly">(
+    "Upcoming"
+  )
+  const CAL_VIEW_ARRAY = ["Upcoming", "Weekly", "Monthly"] as const
 
   return (
     <section className="content-wrapper m-0">
@@ -76,8 +85,15 @@ export function EventSection({
                 <p className="font-serif italic text-black text-xl mt-3 mb-3">
                   What’s next at CCV
                 </p>
-                <Button className="h-[55px] font-semibold" variant="primary_filled">
-                  <a href={events_url} target="_blank" rel="noopener noreferrer">
+                <Button
+                  className="h-[55px] font-semibold"
+                  variant="primary_filled"
+                >
+                  <a
+                    href={events_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
                     View All Events
                   </a>
                 </Button>
@@ -88,9 +104,14 @@ export function EventSection({
           {/* Right: event cards grid */}
           <div>
             <div className="grid grid-cols-1 md:grid-cols-2 [@media(min-width:1400px)]:grid-cols-4 gap-6">
-              {dataFuture?.slice(0, 4).map((e, i) => (
-                <CalendarEvent key={i} {...e} />
-              ))}
+              {dataFuture
+                ?.slice(0, 4)
+                .map(
+                  (
+                    e: JSX.IntrinsicAttributes & DataProps,
+                    i: Key | null | undefined
+                  ) => <CalendarEvent key={i} {...e} />
+                )}
             </div>
           </div>
         </div>

--- a/components/EventSection.tsx
+++ b/components/EventSection.tsx
@@ -12,11 +12,14 @@ import { Button } from "@/components/ui/button"
 const events_url = "https://events.brown.edu/ccv/all"
 
 export interface DataProps {
+  id: number
+  date: string
   date_utc: string
   date2_utc: string
   date_iso: string
   date_time: string
   title: string
+  description_long: string
   url: string
 }
 

--- a/components/EventSection.tsx
+++ b/components/EventSection.tsx
@@ -1,8 +1,6 @@
-// components/EventSection.tsx
 "use client"
 
-import { JSX, Key, use, useState } from "react"
-import CalendarEvent from "@/components/calendar/CalendarEvent"
+import { JSX, use, useState } from "react"
 import CalendarWeekly from "@/components/calendar/CalendarWeekly"
 import CalendarMonth from "@/components/calendar/CalendarMonth"
 import UpcomingEvents from "@/components/calendar/UpcomingEvents"
@@ -33,6 +31,12 @@ interface EventSectionProps {
   currentDate: Date
 }
 
+interface ToggleButtonProps {
+  item: "Upcoming" | "Weekly" | "Monthly"
+  view: "Upcoming" | "Weekly" | "Monthly"
+  setView: (view: "Upcoming" | "Weekly" | "Monthly") => void
+}
+
 const EventCard = () => {
   return (
     <Card className="w-full border-none shadow-none my-auto lg:max-w-xs">
@@ -51,6 +55,23 @@ const EventCard = () => {
         </Button>
       </CardContent>
     </Card>
+  )
+}
+
+const ToggleButton = ({ item, view, setView }: ToggleButtonProps) => {
+  return (
+    <p
+      id={item}
+      key={item}
+      className={classNames(
+        view === item ? "selected" : "",
+        "inline-block m-0 rounded-[13px] py-2 px-3 cursor-pointer"
+      )}
+      role="button"
+      onClick={() => setView(item)}
+    >
+      {item}
+    </p>
   )
 }
 
@@ -91,22 +112,14 @@ export function EventSection({
           {/* Toggle Buttons */}
           <div className="relative mb-12 self-end">
             <div className="toggle-btn space-x-10 text-xl font-semibold absolute right-0 flex">
-              {CAL_VIEW_ARRAY.map((item) => {
-                return (
-                  <p
-                    id={item}
-                    key={item}
-                    className={classNames(
-                      view === item ? "selected" : "",
-                      "inline-block m-0 rounded-[13px] py-2 px-3 cursor-pointer"
-                    )}
-                    role="button"
-                    onClick={() => setView(item)}
-                  >
-                    {item}
-                  </p>
-                )
-              })}
+              {CAL_VIEW_ARRAY.map((item) => (
+                <ToggleButton
+                  key={item}
+                  item={item}
+                  view={view}
+                  setView={setView}
+                />
+              ))}
             </div>
           </div>
 

--- a/components/EventSection.tsx
+++ b/components/EventSection.tsx
@@ -103,7 +103,7 @@ export function EventSection({
       {/* Large Screen Layout (Desktop) */}
       <div className="hidden lg:grid lg:grid-cols-[auto_1fr] gap-6">
         {/* Left: Events card */}
-        <div className="justify-self-start">
+        <div className="justify-self-start mt-9">
           <EventCard />
         </div>
 

--- a/components/EventSection.tsx
+++ b/components/EventSection.tsx
@@ -34,7 +34,7 @@ interface EventSectionProps {
 
 const EventCard = () => {
   return (
-    <Card className="max-w-xs w-full border-none shadow-none my-auto">
+    <Card className="w-full border-none shadow-none my-auto lg:max-w-xs">
       <CardContent className="mb-6 mt-6">
         <CCVBars />
         <h3 className="flex items-center font-semibold text-black text-[32px]">
@@ -68,81 +68,93 @@ export function EventSection({
 
   return (
     <section className="content-wrapper m-0">
-      {/* — Tabs — */}
-      <div className="hidden min-h-8 relative lg:block mb-5">
-        <div className="toggle-btn space-x-10 text-xl font-semibold">
-          {CAL_VIEW_ARRAY.map((item) => {
-            return (
-              <p
-                id={item}
-                key={item}
-                className={classNames(
-                  view === item ? "selected" : "",
-                  item === "Weekly" && "hidden lg:inline-block",
-                  item !== "Weekly" && "inline-block",
-                  "m-0 rounded-[13px] py-2 px-3"
-                )}
-                role="button"
-                onClick={() => setView(item)}
-              >
-                {item}
-              </p>
-            )
-          })}
+      {/* Small Screen Layout (Mobile/Tablet) */}
+      <div className="lg:hidden">
+        <div className="grid grid-cols-1 gap-6">
+          <div className="justify-self-start">
+            <EventCard />
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            {dataFuture
+              ?.slice(0, 4)
+              .map(
+                (
+                  e: JSX.IntrinsicAttributes & DataProps,
+                  i: Key | null | undefined
+                ) => <CalendarEvent key={i} {...e} />
+              )}
+          </div>
         </div>
       </div>
 
-      {/* — Upcoming view — */}
-      {view === "Upcoming" ? (
-        <div className="grid grid-cols-1 [@media(min-width:1400px)]:grid-cols-[auto_1fr] gap-6">
-          {/* Left: Events card */}
-          <div className="justify-self-start [@media(min-width:1400px)]:justify-self-center">
-            <EventCard />
+      {/* Large Screen Layout (Desktop) */}
+      <div className="hidden lg:grid lg:grid-cols-[auto_1fr] gap-6">
+        {/* Left: Events card */}
+        <div className="justify-self-start">
+          <EventCard />
+        </div>
+
+        {/* Right: Toggle and Views */}
+        <div className="flex flex-col">
+          {/* Toggle Buttons */}
+          <div className="relative mb-12 self-end">
+            <div className="toggle-btn space-x-10 text-xl font-semibold absolute right-0 flex">
+              {CAL_VIEW_ARRAY.map((item) => {
+                return (
+                  <p
+                    id={item}
+                    key={item}
+                    className={classNames(
+                      view === item ? "selected" : "",
+                      "inline-block m-0 rounded-[13px] py-2 px-3 cursor-pointer"
+                    )}
+                    role="button"
+                    onClick={() => setView(item)}
+                  >
+                    {item}
+                  </p>
+                )
+              })}
+            </div>
           </div>
 
-          {/* Right: event cards grid */}
-          <div>
-            <div className="grid grid-cols-1 md:grid-cols-2 [@media(min-width:1400px)]:grid-cols-4 gap-6">
-              {dataFuture
-                ?.slice(0, 4)
-                .map(
-                  (
-                    e: JSX.IntrinsicAttributes & DataProps,
-                    i: Key | null | undefined
-                  ) => <CalendarEvent key={i} {...e} />
-                )}
-            </div>
-          </div>
-        </div>
-      ) : (
-        <div className="grid grid-cols-1 [@media(min-width:1400px)]:grid-cols-[auto_1fr] gap-6">
-          {/* Left: Events card */}
-          <div className="justify-self-start [@media(min-width:1400px)]:justify-self-center">
-            <EventCard />
-          </div>
-          {/* — Weekly view — */}
-          {view === "Weekly" && (
-            <div className="h-0 min-h-[1000px]">
-              <CalendarWeekly
-                today={today}
-                currentDate={currentDate}
-                events={dataPast.concat(dataFuture)}
-              />
-            </div>
-          )}
+          {/* Conditional rendering of views */}
+          <div className="mt-1">
+            {view === "Upcoming" && (
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+                {dataFuture
+                  ?.slice(0, 4)
+                  .map(
+                    (
+                      e: JSX.IntrinsicAttributes & DataProps,
+                      i: Key | null | undefined
+                    ) => <CalendarEvent key={i} {...e} />
+                  )}
+              </div>
+            )}
 
-          {/* — Monthly view — */}
-          {view === "Monthly" && (
-            <div className="h-0 min-h-[1000px]">
-              <CalendarMonth
-                today={today}
-                currentDate={currentDate}
-                events={dataPast.concat(dataFuture)}
-              />
-            </div>
-          )}
+            {view === "Weekly" && (
+              <div className="h-0 min-h-[1000px]">
+                <CalendarWeekly
+                  today={today}
+                  currentDate={currentDate}
+                  events={dataPast.concat(dataFuture)}
+                />
+              </div>
+            )}
+
+            {view === "Monthly" && (
+              <div className="h-0 min-h-[1000px]">
+                <CalendarMonth
+                  today={today}
+                  currentDate={currentDate}
+                  events={dataPast.concat(dataFuture)}
+                />
+              </div>
+            )}
+          </div>
         </div>
-      )}
+      </div>
     </section>
   )
 }

--- a/components/EventSection.tsx
+++ b/components/EventSection.tsx
@@ -32,6 +32,27 @@ interface EventSectionProps {
   currentDate: Date
 }
 
+const EventCard = () => {
+  return (
+    <Card className="max-w-xs w-full border-none shadow-none my-auto">
+      <CardContent className="mb-6 mt-6">
+        <CCVBars />
+        <h3 className="flex items-center font-semibold text-black text-[32px]">
+          <FaCalendarAlt className="mr-3" /> Events
+        </h3>
+        <p className="font-serif italic text-black text-xl mt-3 mb-3">
+          What’s next at CCV
+        </p>
+        <Button className="h-[55px] font-semibold" variant="primary_filled">
+          <a href={events_url} target="_blank" rel="noopener noreferrer">
+            View All Events
+          </a>
+        </Button>
+      </CardContent>
+    </Card>
+  )
+}
+
 export function EventSection({
   streamedDataFuture,
   streamedDataPast,
@@ -48,8 +69,8 @@ export function EventSection({
   return (
     <section className="content-wrapper m-0">
       {/* — Tabs — */}
-      <div className="hidden min-h-8 relative lg:block mb-4">
-        <div className="toggle-btn space-x-10">
+      <div className="hidden min-h-8 relative lg:block mb-5">
+        <div className="toggle-btn space-x-10 text-xl font-semibold">
           {CAL_VIEW_ARRAY.map((item) => {
             return (
               <p
@@ -72,33 +93,11 @@ export function EventSection({
       </div>
 
       {/* — Upcoming view — */}
-      {view === "Upcoming" && (
-        <div className="grid grid-cols-1 [@media(min-width:1400px)]:grid-cols-[auto_1fr] gap-6 pt-4">
+      {view === "Upcoming" ? (
+        <div className="grid grid-cols-1 [@media(min-width:1400px)]:grid-cols-[auto_1fr] gap-6">
           {/* Left: Events card */}
           <div className="justify-self-start [@media(min-width:1400px)]:justify-self-center">
-            <Card className="max-w-xs w-full border-none shadow-none my-auto">
-              <CardContent className="mb-6 mt-6">
-                <CCVBars />
-                <h3 className="flex items-center font-semibold text-black text-[32px]">
-                  <FaCalendarAlt className="mr-3" /> Events
-                </h3>
-                <p className="font-serif italic text-black text-xl mt-3 mb-3">
-                  What’s next at CCV
-                </p>
-                <Button
-                  className="h-[55px] font-semibold"
-                  variant="primary_filled"
-                >
-                  <a
-                    href={events_url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    View All Events
-                  </a>
-                </Button>
-              </CardContent>
-            </Card>
+            <EventCard />
           </div>
 
           {/* Right: event cards grid */}
@@ -115,27 +114,33 @@ export function EventSection({
             </div>
           </div>
         </div>
-      )}
+      ) : (
+        <div className="grid grid-cols-1 [@media(min-width:1400px)]:grid-cols-[auto_1fr] gap-6">
+          {/* Left: Events card */}
+          <div className="justify-self-start [@media(min-width:1400px)]:justify-self-center">
+            <EventCard />
+          </div>
+          {/* — Weekly view — */}
+          {view === "Weekly" && (
+            <div className="h-0 min-h-[1000px]">
+              <CalendarWeekly
+                today={today}
+                currentDate={currentDate}
+                events={dataPast.concat(dataFuture)}
+              />
+            </div>
+          )}
 
-      {/* — Weekly view — */}
-      {view === "Weekly" && (
-        <div className="h-0 min-h-[768px] pt-4">
-          <CalendarWeekly
-            today={today}
-            currentDate={currentDate}
-            events={dataPast.concat(dataFuture)}
-          />
-        </div>
-      )}
-
-      {/* — Monthly view — */}
-      {view === "Monthly" && (
-        <div className="pt-4">
-          <CalendarMonth
-            today={today}
-            currentDate={currentDate}
-            events={dataPast.concat(dataFuture)}
-          />
+          {/* — Monthly view — */}
+          {view === "Monthly" && (
+            <div className="h-0 min-h-[1000px]">
+              <CalendarMonth
+                today={today}
+                currentDate={currentDate}
+                events={dataPast.concat(dataFuture)}
+              />
+            </div>
+          )}
         </div>
       )}
     </section>

--- a/components/EventSection.tsx
+++ b/components/EventSection.tsx
@@ -5,6 +5,7 @@ import { JSX, Key, use, useState } from "react"
 import CalendarEvent from "@/components/calendar/CalendarEvent"
 import CalendarWeekly from "@/components/calendar/CalendarWeekly"
 import CalendarMonth from "@/components/calendar/CalendarMonth"
+import UpcomingEvents from "@/components/calendar/UpcomingEvents"
 import { Card, CardContent } from "@/components/ui/card"
 import CCVBars from "@/components/assets/CCVBars"
 import { FaCalendarAlt } from "react-icons/fa"
@@ -74,16 +75,7 @@ export function EventSection({
           <div className="justify-self-start">
             <EventCard />
           </div>
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-            {dataFuture
-              ?.slice(0, 4)
-              .map(
-                (
-                  e: JSX.IntrinsicAttributes & DataProps,
-                  i: Key | null | undefined
-                ) => <CalendarEvent key={i} {...e} />
-              )}
-          </div>
+          <UpcomingEvents events={dataFuture} />
         </div>
       </div>
 
@@ -120,18 +112,7 @@ export function EventSection({
 
           {/* Conditional rendering of views */}
           <div className="mt-1">
-            {view === "Upcoming" && (
-              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-                {dataFuture
-                  ?.slice(0, 4)
-                  .map(
-                    (
-                      e: JSX.IntrinsicAttributes & DataProps,
-                      i: Key | null | undefined
-                    ) => <CalendarEvent key={i} {...e} />
-                  )}
-              </div>
-            )}
+            {view === "Upcoming" && <UpcomingEvents events={dataFuture} />}
 
             {view === "Weekly" && (
               <div className="h-0 min-h-[1000px]">

--- a/components/calendar/CalendarEvent.tsx
+++ b/components/calendar/CalendarEvent.tsx
@@ -30,7 +30,7 @@ const CalendarEvent: React.FC<DataProps> = ({
           {title}
         </a>
       </div>
-      <div className="md:text-lg md:text-xl flex items-center text-keppel-500">
+      <div className="md:text-lg md:text-xl flex items-center text-keppel-700">
         <ClockIcon className="mr-2 h-4 w-4" aria-hidden="true" />
         {date_time}
       </div>

--- a/components/calendar/CalendarEvent.tsx
+++ b/components/calendar/CalendarEvent.tsx
@@ -21,7 +21,7 @@ const CalendarEvent: React.FC<DataProps> = ({
       <div className="text-neutral-900 font-semibold text-sm">{normalDate}</div>
       <div>
         <a
-          className="text-2xl font-bold text-500 no-underline hover:underline leading-6"
+          className="text-2xl font-bold text-blue-500 no-underline hover:underline leading-6"
           href={url}
           target="_blank"
         >

--- a/components/calendar/CalendarEvent.tsx
+++ b/components/calendar/CalendarEvent.tsx
@@ -18,17 +18,19 @@ const CalendarEvent: React.FC<DataProps> = ({
     date
   return (
     <div className="bg-gray-50 p-4 space-y-2">
-      <div className="text-neutral-900 font-semibold text-sm">{normalDate}</div>
+      <div className="text-lg md:text-xl text-neutral-900 font-semibold">
+        {normalDate}
+      </div>
       <div>
         <a
-          className="text-2xl font-bold text-blue-500 no-underline hover:underline leading-6"
+          className="text-xl md:text-2xl font-bold text-blue-500 no-underline hover:underline leading-6"
           href={url}
           target="_blank"
         >
           {title}
         </a>
       </div>
-      <div className="flex items-center text-keppel-500 text-sm">
+      <div className="md:text-lg md:text-xl flex items-center text-keppel-500">
         <ClockIcon className="mr-2 h-4 w-4" aria-hidden="true" />
         {date_time}
       </div>

--- a/components/calendar/CalendarHeading.tsx
+++ b/components/calendar/CalendarHeading.tsx
@@ -18,8 +18,8 @@ export const CalendarHeading: React.FC<CalendarHeadingProps> = ({
   todayButtonFunction,
 }) => {
   return (
-    <header className="flex items-center justify-between border border-gray-200 px-6 py-4 mt-3 mb-2 bg-gray-50 rounded-md lg:flex-none">
-      <h1 className="text-base font-semibold text-neutral-700 text-xl">
+    <header className="flex items-center justify-between border border-gray-200 px-6 py-4 mt-0 mb-2 bg-gray-50 rounded-md lg:flex-none">
+      <h1 className="text-base font-semibold text-blue-500 text-xl">
         <time dateTime={date.toISOString()}>
           {`${ALL_MONTHS[date.getMonth()]} ${date.getFullYear()}`}
         </time>

--- a/components/calendar/CalendarHeading.tsx
+++ b/components/calendar/CalendarHeading.tsx
@@ -19,7 +19,7 @@ export const CalendarHeading: React.FC<CalendarHeadingProps> = ({
 }) => {
   return (
     <header className="flex items-center justify-between border border-gray-200 px-6 py-4 mt-3 mb-2 bg-gray-50 rounded-md lg:flex-none">
-      <h1 className="text-base font-semibold text-700">
+      <h1 className="text-base font-semibold text-neutral-700 text-xl">
         <time dateTime={date.toISOString()}>
           {`${ALL_MONTHS[date.getMonth()]} ${date.getFullYear()}`}
         </time>
@@ -36,7 +36,7 @@ export const CalendarHeading: React.FC<CalendarHeadingProps> = ({
           </button>
           <button
             type="button"
-            className="hidden border border-gray-300 px-3.5 text-sm font-semibold text-gray-900 hover:bg-gray-50 focus:relative md:block"
+            className="hidden border border-gray-300 px-3.5 text-xl font-semibold text-neutral-900 hover:bg-gray-50 focus:relative md:block"
             onClick={() => todayButtonFunction()}
           >
             Today
@@ -47,7 +47,7 @@ export const CalendarHeading: React.FC<CalendarHeadingProps> = ({
             className="flex h-9 w-12 items-center justify-center rounded-r-md border-y border-r border-gray-300 pl-1 text-gray-400 hover:text-gray-500 focus:relative md:w-9 md:pl-0 md:hover:bg-gray-50"
             onClick={() => nextButtonFunction()}
           >
-            <span className="sr-only">Next {srButtonText}</span>
+            <span className="sr-only text-xl">Next {srButtonText}</span>
             <ChevronRightIcon className="h-5 w-5" aria-hidden="true" />
           </button>
         </div>

--- a/components/calendar/CalendarMonth.tsx
+++ b/components/calendar/CalendarMonth.tsx
@@ -133,10 +133,10 @@ const CalendarMonth: React.FC<CalendarProps> = ({
 
                 <time
                   dateTime={event.date_utc}
-                  className="hidden flex-none text-keppel-500 group-hover:text-keppel-500 group-hover:font-semibold xl:flex xl:items-center"
+                  className="hidden flex-none text-keppel-700 group-hover:text-keppel-700 group-hover:font-semibold xl:flex xl:items-center"
                 >
                   <ClockIcon
-                    className="mr-1 h-4 w-4 text-keppel-500"
+                    className="mr-1 h-4 w-4 text-keppel-700"
                     aria-hidden="true"
                   />
                   {event.date_time}

--- a/components/calendar/CalendarMonth.tsx
+++ b/components/calendar/CalendarMonth.tsx
@@ -107,9 +107,12 @@ const CalendarMonth: React.FC<CalendarProps> = ({
         <li key={self.crypto.randomUUID()}>
           <TooltipProvider>
             <Tooltip>
-              <TooltipTrigger className="rounded-md max-w-full px-2 hover:bg-neutral-50">
+              <TooltipTrigger
+                asChild
+                className="rounded-md max-w-full px-2 hover:bg-neutral-50"
+              >
                 <a href={event.url} target="_blank">
-                  <p className="flex-auto min-w-0 truncate font-medium text-700">
+                  <p className="flex-auto min-w-0 truncate text-lg text-blue-500 font-semibold">
                     {event.title}
                   </p>
                 </a>
@@ -119,7 +122,7 @@ const CalendarMonth: React.FC<CalendarProps> = ({
                 <a
                   href={event.url}
                   target="_blank"
-                  className="flex gap-1 text-500"
+                  className="flex gap-1 text-blue-500"
                 >
                   <p className="font-semibold hover:underline">{event.title}</p>
                   <ArrowTopRightOnSquareIcon
@@ -130,7 +133,7 @@ const CalendarMonth: React.FC<CalendarProps> = ({
 
                 <time
                   dateTime={event.date_utc}
-                  className="hidden flex-none text-keppel-500 group-hover:text-500 group-hover:font-semibold xl:flex xl:items-center"
+                  className="hidden flex-none text-keppel-500 group-hover:text-keppel-500 group-hover:font-semibold xl:flex xl:items-center"
                 >
                   <ClockIcon
                     className="mr-1 h-4 w-4 text-keppel-500"
@@ -155,7 +158,7 @@ const CalendarMonth: React.FC<CalendarProps> = ({
             <a
               href={event.url}
               target="_blank"
-              className="flex gap-1 text-500"
+              className="flex gap-1 text-blue-500"
             >
               <p className="font-semibold hover:underline">{event.title}</p>
               <ArrowTopRightOnSquareIcon
@@ -206,8 +209,8 @@ const CalendarMonth: React.FC<CalendarProps> = ({
             dateTime={day.dateString}
             className={
               day.isToday
-                ? "flex h-6 w-6 items-center justify-center rounded-full bg-sunglow-yellow-500 font-semibold"
-                : undefined
+                ? "flex h-9 w-9 items-center justify-center rounded-full bg-sunglow-400 font-semibold text-lg"
+                : "flex h-9 w-9 items-center justify-center text-lg"
             }
           >
             {day.dayOfMonth}
@@ -242,7 +245,7 @@ const CalendarMonth: React.FC<CalendarProps> = ({
             isSameDay(day.date, selectedDate) && "text-white",
             !isSameDay(day.date, selectedDate) &&
               day.isToday &&
-              "text-500 bg-sunglow-yellow-500",
+              "text-blue-500 bg-sunglow-400",
             !isSameDay(day.date, selectedDate) &&
               day.isCurrentMonth &&
               !day.isToday &&
@@ -260,7 +263,7 @@ const CalendarMonth: React.FC<CalendarProps> = ({
               isSameDay(day.date, selectedDate) &&
                 "flex h-6 w-6 items-center justify-center rounded-full",
               day.isToday &&
-                "flex h-6 w-6 items-center justify-center rounded-full bg-sunglow-yellow-500",
+                "flex h-6 w-6 items-center justify-center rounded-full bg-sunglow-400",
               isSameDay(day.date, selectedDate) &&
                 !day.isToday &&
                 "bg-gray-900",
@@ -309,7 +312,7 @@ const CalendarMonth: React.FC<CalendarProps> = ({
             : numberOfWeeks === 5
               ? "lg:grid-rows-5"
               : "lg:grid-rows-6",
-          "hidden w-full lg:grid lg:grid-cols-7 lg:gap-px"
+          "hidden w-full lg:grid lg:grid-cols-7 lg:gap-[3px]"
         )}
       >
         {month}
@@ -330,7 +333,7 @@ const CalendarMonth: React.FC<CalendarProps> = ({
         Click on a date to see a list of its events!
       </p>
       <div className="shadow ring-1 ring-black ring-opacity-5 lg:flex lg:flex-auto lg:flex-col">
-        <div className="grid grid-cols-7 gap-px border-b border-gray-300 bg-gray-200 text-center text-xs/6 font-semibold text-gray-700 lg:flex-none">
+        <div className="grid grid-cols-7 gap-[3px] border-b border-gray-300 bg-gray-200 text-center text-lg font-semibold text-gray-700 lg:flex-none">
           <div className="bg-white py-2">
             S<span className="sr-only sm:not-sr-only">un</span>
           </div>

--- a/components/calendar/CalendarWeekly.tsx
+++ b/components/calendar/CalendarWeekly.tsx
@@ -92,14 +92,14 @@ const CalendarWeekly: React.FC<CalendarProps> = ({
           className={`flex items-center justify-center py-3 ${
             isSameMonth(thisDate, activeDate) ? "" : "inactiveDay"
           } ${isSameDay(thisDate, selectedDate) ? "selectedDay" : ""}
-          ${isSameDay(thisDate, currentDate) ? "today bg-sunglow-yellow-50" : "bg-white"}`}
+          ${isSameDay(thisDate, currentDate) ? "today bg-sunglow-50" : "bg-white"}`}
           onClick={() => {
             setSelectedDate(cloneDate)
           }}
         >
-          <span>
+          <span className="text-neutral-900 font-semibold">
             {day}
-            <span className="mx-2 items-center justify-center font-semibold text-gray-900">
+            <span className="mx-2 items-center justify-center">
               {format(thisDate, "d")}
             </span>
           </span>
@@ -133,11 +133,11 @@ const CalendarWeekly: React.FC<CalendarProps> = ({
 
       const calColor =
         event.title === "CCV Office Hours"
-          ? "bg-50 hover:bg-300"
+          ? "bg-keppel-100 hover:bg-keppel-300"
           : event.title ===
               "COBRE CBC Computational Biology Walk-in Office hours"
-            ? "bg-50 hover:bg-300"
-            : "bg-keppel-50 hover:bg-keppel-500"
+            ? "bg-keppel-100 hover:bg-keppel-300"
+            : "bg-keppel-100 hover:bg-keppel-300"
 
       return (
         <li
@@ -152,9 +152,7 @@ const CalendarWeekly: React.FC<CalendarProps> = ({
             target={"_blank"}
             className={`${calColor} group absolute inset-1 flex flex-col overflow-y-auto rounded-lg p-2 text-xs leading-5`}
           >
-            <p className="order-1 font-semibold text-700">
-              {event.title}
-            </p>
+            <p className="order-1 font-semibold text-blue-500">{event.title}</p>
             <p className="weekly-datetime">
               <time dateTime={event.date_utc}>{event.date_time}</time>
             </p>
@@ -222,7 +220,7 @@ const CalendarWeekly: React.FC<CalendarProps> = ({
                 {DAY_COLUMN_ARRAY.map(({ day, key }) => (
                   <div
                     key={key}
-                    className={`row-span-full ${CAL_STYLE_ARRAY[day]} ${day === 7 ? "w-8" : ""} ${day === todayRow && isSameDay(activeDate, currentDate) ? "bg-sunglow-yellow-50" : ""}`}
+                    className={`row-span-full ${CAL_STYLE_ARRAY[day]} ${day === 7 ? "w-8" : ""} ${day === todayRow && isSameDay(activeDate, currentDate) ? "bg-sunglow-50 bg-opacity-30" : ""}`}
                   />
                 ))}
               </div>

--- a/components/calendar/CalendarWeekly.tsx
+++ b/components/calendar/CalendarWeekly.tsx
@@ -23,6 +23,7 @@ import {
 
 import { CalendarProps } from "@/components/calendar/types"
 import { CalendarHeading } from "@/components/calendar/CalendarHeading"
+import { ClockIcon } from "@heroicons/react/20/solid"
 
 export interface weekProps {
   id: string
@@ -131,7 +132,7 @@ const CalendarWeekly: React.FC<CalendarProps> = ({
         new Date(yearEvent, monthEvent, dateEvent)
       )
 
-      const calColor = "bg-keppel-100 hover:bg-keppel-300"
+      const calColor = "bg-sunglow-300 hover:bg-sunglow-200"
 
       return (
         <li
@@ -146,10 +147,11 @@ const CalendarWeekly: React.FC<CalendarProps> = ({
             target={"_blank"}
             className={`${calColor} group absolute inset-1 flex flex-col overflow-y-auto rounded-lg p-2 text-sm md:text-md lg:text-xl leading-5`}
           >
-            <p className="weekly-datetime">
+            <p className="font-semibold text-blue-500">{event.title}</p>
+            <p className="weekly-datetime text-keppel-700 flex items-center py-2">
+              <ClockIcon className="mr-2 h-4 w-4" aria-hidden="true" />
               <time dateTime={event.date_utc}>{event.date_time}</time>
             </p>
-            <p className="font-semibold text-blue-500 py-2">{event.title}</p>
           </a>
         </li>
       )
@@ -214,7 +216,7 @@ const CalendarWeekly: React.FC<CalendarProps> = ({
                 {DAY_COLUMN_ARRAY.map(({ day, key }) => (
                   <div
                     key={key}
-                    className={`row-span-full ${CAL_STYLE_ARRAY[day]} ${day === 7 ? "w-8" : ""} ${day === todayRow && isSameDay(activeDate, currentDate) ? "bg-sunglow-50 bg-opacity-30" : ""}`}
+                    className={`row-span-full ${CAL_STYLE_ARRAY[day]} ${day === 7 ? "w-8" : ""} ${day === todayRow && isSameDay(activeDate, currentDate) ? "bg-sunglow-100 bg-opacity-30" : ""}`}
                   />
                 ))}
               </div>

--- a/components/calendar/CalendarWeekly.tsx
+++ b/components/calendar/CalendarWeekly.tsx
@@ -97,7 +97,7 @@ const CalendarWeekly: React.FC<CalendarProps> = ({
             setSelectedDate(cloneDate)
           }}
         >
-          <span className="text-neutral-900 font-semibold">
+          <span className="text-neutral-900 font-semibold text-lg">
             {day}
             <span className="mx-2 items-center justify-center">
               {format(thisDate, "d")}
@@ -150,12 +150,12 @@ const CalendarWeekly: React.FC<CalendarProps> = ({
           <a
             href={event.url}
             target={"_blank"}
-            className={`${calColor} group absolute inset-1 flex flex-col overflow-y-auto rounded-lg p-2 text-xs leading-5`}
+            className={`${calColor} group absolute inset-1 flex flex-col overflow-y-auto rounded-lg p-2 text-sm md:text-md lg:text-xl leading-5`}
           >
-            <p className="order-1 font-semibold text-blue-500">{event.title}</p>
             <p className="weekly-datetime">
               <time dateTime={event.date_utc}>{event.date_time}</time>
             </p>
+            <p className="font-semibold text-blue-500 py-2">{event.title}</p>
           </a>
         </li>
       )

--- a/components/calendar/CalendarWeekly.tsx
+++ b/components/calendar/CalendarWeekly.tsx
@@ -131,13 +131,7 @@ const CalendarWeekly: React.FC<CalendarProps> = ({
         new Date(yearEvent, monthEvent, dateEvent)
       )
 
-      const calColor =
-        event.title === "CCV Office Hours"
-          ? "bg-keppel-100 hover:bg-keppel-300"
-          : event.title ===
-              "COBRE CBC Computational Biology Walk-in Office hours"
-            ? "bg-keppel-100 hover:bg-keppel-300"
-            : "bg-keppel-100 hover:bg-keppel-300"
+      const calColor = "bg-keppel-100 hover:bg-keppel-300"
 
       return (
         <li

--- a/components/calendar/UpcomingEvents.tsx
+++ b/components/calendar/UpcomingEvents.tsx
@@ -1,0 +1,27 @@
+import { JSX, Key } from "react"
+import CalendarEvent from "@/components/calendar/CalendarEvent"
+import { DataProps } from "@/components/EventSection"
+
+interface UpcomingEventsViewProps {
+  events: DataProps[]
+  limit?: number
+}
+
+const UpcomingEventsView = ({
+  events,
+  limit = 4,
+}: UpcomingEventsViewProps): JSX.Element => {
+  const displayedEvents = limit ? events?.slice(0, limit) : events
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+      {displayedEvents?.map(
+        (e: JSX.IntrinsicAttributes & DataProps, i: Key | null | undefined) => (
+          <CalendarEvent key={i} {...e} />
+        )
+      )}
+    </div>
+  )
+}
+
+export default UpcomingEventsView

--- a/components/ui/tooltip.tsx
+++ b/components/ui/tooltip.tsx
@@ -20,7 +20,7 @@ const TooltipContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "TooltipContent z-50 overflow-hidden rounded-md bg-neutral-50 px-3 py-1.5 text-lg",
+        "z-50 overflow-hidden rounded-md bg-neutral-50 px-3 py-1.5 text-lg",
         className
       )}
       {...props}

--- a/components/ui/tooltip.tsx
+++ b/components/ui/tooltip.tsx
@@ -20,7 +20,7 @@ const TooltipContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 overflow-hidden min-w-48 rounded-md bg-neutral-50 px-3 py-1.5 text-xs animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "TooltipContent z-50 overflow-hidden rounded-md bg-neutral-50 px-3 py-1.5 text-lg",
         className
       )}
       {...props}


### PR DESCRIPTION
Updated the event section:
* Added Event Card back to weekly and monthly views
* Updated colors to tailwind config colors
* Increased text size 
* Increased monthly calendar grid gaps 

Issues: 
* ~~I don't love the current stacking on smaller screens. The event card goes between the toggle and calendars. It would probably be better to make everything disappear and revert to "Upcoming" view for smaller screens.~~ [Fixed] 