### PR TITLE
improve mobile navbar style

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -286,10 +286,10 @@ export const Navbar: React.FC = () => {
         {isMobileMenuOpen && (
           <div className="lg:hidden absolute top-full left-0 w-full bg-neutral-700 shadow-md z-40 overflow-y-auto max-h-screen">
             {routes.map((section) => (
-              <div key={section.name} className="mb-4">
+              <div key={section.name}>
                 <button
                   onClick={() => toggleSubmenu(section.name)}
-                  className="flex items-center justify-between w-full text-sunglow-400 font-semibold text-3xl py-6 px-6 mr-6 hover:bg-sunglow-400 hover:text-black active:bg-sunglow-200"
+                  className="flex items-center justify-between w-full text-sunglow-400 font-semibold text-3xl py-7 px-6 mr-6 hover:bg-sunglow-400 hover:text-black active:bg-sunglow-200"
                 >
                   {section.name}
                   <FiChevronDownIcon className={`h-8 w-8 transition-transform ${openSubmenus.includes(section.name) ? 'rotate-180' : ''}`} />
@@ -309,13 +309,13 @@ export const Navbar: React.FC = () => {
                 )}
               </div>
             ))}
-            <Link href="/blog" className="flex text-sunglow-400 font-semibold text-3xl py-7 px-6 mr-6 hover:bg-sunglow-400 hover:text-black active:bg-sunglow-200">
+            <Link href="/blog" className="flex text-sunglow-400 font-semibold text-3xl py-7 px-6 hover:bg-sunglow-400 hover:text-black active:bg-sunglow-200">
               Blog
             </Link>
-            <Link href="/help" className="block text-sunglow-400 font-semibold text-3xl py-7 px-6 mr-6 hover:bg-sunglow-400 hover:text-black active:bg-sunglow-200">
+            <Link href="/help" className="block text-sunglow-400 font-semibold text-3xl py-7 px-6 hover:bg-sunglow-400 hover:text-black active:bg-sunglow-200">
               Help
             </Link>
-            <a href="https://docs.ccv.brown.edu/documentation" target="_blank" rel="noopener noreferrer" className="block text-sunglow-400 font-semibold text-3xl py-7 pl-6 mr-6 hover:bg-sunglow-400 hover:text-black active:bg-sunglow-200">
+            <a href="https://docs.ccv.brown.edu/documentation" target="_blank" rel="noopener noreferrer" className="block text-sunglow-400 font-semibold text-3xl py-7 pl-6 hover:bg-sunglow-400 hover:text-black active:bg-sunglow-200">
               Docs
             </a>
           </div>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -284,47 +284,40 @@ export const Navbar: React.FC = () => {
 
         {/* Mobile Menu */}
         {isMobileMenuOpen && (
-          <div className="lg:hidden absolute top-full left-0 w-full bg-neutral-900 shadow-md z-40 p-4 overflow-y-auto max-h-screen">
+          <div className="lg:hidden absolute top-full left-0 w-full bg-neutral-700 shadow-md z-40 overflow-y-auto max-h-screen">
             {routes.map((section) => (
-              <div key={section.name} className="mb-4 outline-double">
-                {section.name === "Blog" ? (
-                  <Link href="/blog" className="block text-white font-semibold text-2xl py-2 tracking-widest">
-                    {section.name}
-                  </Link>
-                ) : (
-                  <>
-                    <button
-                      onClick={() => toggleSubmenu(section.name)}
-                      className="flex items-center justify-between w-full font-semibold text-sunglow-400 tracking-widest text-2xl py-6 px-6"
-                    >
-                      {section.name}
-                      <FiChevronDownIcon className={`h-4 w-4 transition-transform ${openSubmenus.includes(section.name) ? 'rotate-180' : ''}`} />
-                    </button>
-                    {openSubmenus.includes(section.name) && (
-                      <div className="ml-6">
-                        {section.groups.map(group => (
-                          <div className="py-2" key={group.name}>
-                            {group.routes.map(route => (
-                              <Link key={route.href} href={route.href} className="block text-white text-xl py-6 pl-6 mr-6 hover:bg-sunglow-400 hover:text-black active:bg-sunglow-200">
-                                {route.name}
-                              </Link>
-                            ))}
-                          </div>
+              <div key={section.name} className="mb-4">
+                <button
+                  onClick={() => toggleSubmenu(section.name)}
+                  className="flex items-center justify-between w-full text-sunglow-400 font-semibold text-3xl py-6 px-6 mr-6 hover:bg-sunglow-400 hover:text-black active:bg-sunglow-200"
+                >
+                  {section.name}
+                  <FiChevronDownIcon className={`h-8 w-8 transition-transform ${openSubmenus.includes(section.name) ? 'rotate-180' : ''}`} />
+                </button>
+                {openSubmenus.includes(section.name) && (
+                  <div className="ml-6">
+                    {section.groups.map(group => (
+                      <div className="py-2" key={group.name}>
+                        {group.routes.map(route => (
+                          <Link key={route.href} href={route.href} className="block text-white text-xl py-6 px-6 mr-6 hover:bg-sunglow-400 hover:text-black active:bg-sunglow-200">
+                            {route.name}
+                          </Link>
                         ))}
                       </div>
-                    )}
-                  </>
+                    ))}
+                  </div>
                 )}
               </div>
             ))}
-            <div className="mt-4">
-              <Link href="/help" className="block text-sunglow-400 font-semibold text-2xl tracking-widest py-6 pl-6 mr-6 hover:bg-sunglow-400 hover:text-black active:bg-sunglow-200">
-                Help
-              </Link>
-              <a href="https://docs.ccv.brown.edu/documentation" target="_blank" rel="noopener noreferrer" className="block text-sunglow-400 font-semibold text-2xl tracking-widest py-6 pl-6 mr-6 hover:bg-sunglow-400 hover:text-black active:bg-sunglow-200">
-                Docs
-              </a>
-            </div>
+            <Link href="/blog" className="flex text-sunglow-400 font-semibold text-3xl py-7 px-6 mr-6 hover:bg-sunglow-400 hover:text-black active:bg-sunglow-200">
+              Blog
+            </Link>
+            <Link href="/help" className="block text-sunglow-400 font-semibold text-3xl py-7 px-6 mr-6 hover:bg-sunglow-400 hover:text-black active:bg-sunglow-200">
+              Help
+            </Link>
+            <a href="https://docs.ccv.brown.edu/documentation" target="_blank" rel="noopener noreferrer" className="block text-sunglow-400 font-semibold text-3xl py-7 pl-6 mr-6 hover:bg-sunglow-400 hover:text-black active:bg-sunglow-200">
+              Docs
+            </a>
           </div>
         )}
       </nav>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -277,7 +277,7 @@ export const Navbar: React.FC = () => {
 
         {/* Mobile Menu Hamburger Button */}
         <div className="lg:hidden flex items-center">
-          <Button variant="secondary_filled" size="icon" className="text-blue-navbar rounded-none" onClick={toggleMobileMenu}>
+          <Button variant="secondary_filled" size="icon" className="text-blue-navbar rounded-2xl" onClick={toggleMobileMenu}>
             <FiMenu className="h-6 w-6" />
           </Button>
         </div>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import React, { useState } from "react"
+import React, { useState, useEffect } from "react"
 import { Button } from "@/components/ui/button"
 import CCVLogo from "@/components/assets/CCVLogo"
 import Link from "next/link"
@@ -189,11 +189,20 @@ const routes: NavSection[] = [
 
 export const Navbar: React.FC = () => {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
-  const [openSubmenus, setOpenSubmenus] = useState<string[]>([]); // Array to track open submenus
+  const [openSubmenus, setOpenSubmenus] = useState<string[]>([]);
 
   const toggleMobileMenu = () => {
     setIsMobileMenuOpen(!isMobileMenuOpen)
+    // Prevent body scrolling when mobile menu is open
+    document.body.style.overflow = isMobileMenuOpen ? 'auto' : 'hidden';
   }
+
+  // Effect to clean up body overflow style when component unmounts
+  useEffect(() => {
+    return () => {
+      document.body.style.overflow = 'auto'; // ensures body scrolling is re-enabled
+    };
+  }, []);
 
   const toggleSubmenu = (sectionName: string) => {
     if (openSubmenus.includes(sectionName)) {
@@ -206,7 +215,6 @@ export const Navbar: React.FC = () => {
   return (
     <header className={`sticky top-0 z-50`}>
       <nav className="bg-blue-navbar flex px-8 justify-between">
-        {/* CCV Logo */}
         <div className="flex items-center py-8 px-6 xl:px-10">
           <Link href={"/"}>
             <CCVLogo width={120}/>
@@ -282,9 +290,24 @@ export const Navbar: React.FC = () => {
           </Button>
         </div>
 
-        {/* Mobile Menu */}
+        {/* Mobile Menu Content */}
         {isMobileMenuOpen && (
-          <div className="lg:hidden absolute top-full left-0 w-full bg-neutral-700 shadow-md z-40 overflow-y-auto max-h-screen">
+          <div
+            className="
+              absolute
+              left-0 
+              w-full 
+              max-h-screen
+              lg:hidden
+              top-full
+              bg-neutral-700
+              shadow-md
+              z-40
+              overflow-y-auto
+              h-screen
+              pb-4
+            "
+          >
             {routes.map((section) => (
               <div key={section.name}>
                 <button


### PR DESCRIPTION
This PR: 
- rounds out the hamburger button so it's more in line with CCV styles not Brown styles
- in navbar items with subitems, increase the up/down arrow size and highlight the div in sunglow on hover
- adds back in missing Blog item
- removes the outlines around the main menu items
- removes "wide tracking" on the main menu items