### PR TITLE
fix: expand/make generic the interfaces for storage and about pages (so far)

### DIFF
--- a/app/about/contact/page.tsx
+++ b/app/about/contact/page.tsx
@@ -8,21 +8,10 @@ import { cn } from "@/lib/utils";
 import { cardVariants } from "@/components/ui/variants";
 import { readContentFile } from "@/lib/content-utils"
 import Icon from "@/components/ui/render-icon";
+import { ContactUsTypes, OfficeHoursTypes, PageContentData } from "@/lib/about-types";
 
-interface ContactTypes {
-  title: string;
-  icon?: string;
-  description: string;
-  buttonLinks?: { text: string; href: string }[];
-}
-interface OfficeHoursTypes {
-  title: string;
-  subtitle: string;
-  description: string;
-  buttonLinks?: { text: string; href: string }[];
-}
-
-const pageContent = await readContentFile('content/about/contact.yaml');
+const loadedContent = await readContentFile<PageContentData>('content/about/contact.yaml');
+const pageContent: PageContentData = loadedContent.data;
 
 export default async function ContactUs() {
   return (
@@ -57,7 +46,7 @@ export default async function ContactUs() {
 
         <div className="content-wrapper flex justify-center px-40">
           <div className="flex flex-wrap justify-center gap-y-6 gap-x-6 xs:w-1/2">
-            {pageContent?.data?.contactUs?.map((card: ContactTypes) => (
+            {pageContent?.contactUs?.map((card: ContactUsTypes) => (
               <div
                 key={card.title}
                 className="flex-grow max-w-lg"
@@ -107,7 +96,7 @@ export default async function ContactUs() {
         <div>
           <section className="content-wrapper">
             <div className="flex flex-wrap justify-center gap-y-6 gap-x-6">
-              {pageContent?.data?.officeHours?.map((card: OfficeHoursTypes) => (
+              {pageContent?.officeHours?.map((card: OfficeHoursTypes) => (
                 <div
                   key={card.title}
                   className="flex-grow max-w-md"

--- a/app/about/us/page.tsx
+++ b/app/about/us/page.tsx
@@ -6,22 +6,12 @@ import { SectionHeader } from "@/components/ui/section-header"
 import { Card, CardContent } from "@/components/ui/card"
 import { CardWithImage } from "@/components/ui/people-card"
 import { readContentFile } from "@/lib/content-utils"
-
-interface peopleTypes{
-  name: string;
-  type: string;
-  team: string;
-  subteam: string;
-  title: string;
-  github_username: string;
-  brown_directory_uuid: string;
-  bio: string;
-  image: string;
-}
+import { PeopleTypes, PageContentData } from "@/lib/about-types"
 
 function imagePath(imageName: string) {return path.join('/images/people', imageName)}
 
-const pageContent = await readContentFile('content/about/us.yaml');
+const loadedContent = await readContentFile<PageContentData>('content/about/us.yaml');
+const pageContent: PageContentData = loadedContent.data;
 
 export default async function AboutUs() {
     return (
@@ -72,7 +62,7 @@ export default async function AboutUs() {
           <SectionHeader title="People" align="center"></SectionHeader>
             <div className="flex justify-center">
               <div className="flex flex-wrap justify-center gap-y-6 xs:w-1/2">
-              {pageContent?.data?.map((person: peopleTypes) => (
+              {pageContent?.people.map((person: PeopleTypes) => (
                 <div key={person.name}>
                   <CardWithImage 
                     imagePath={imagePath(person?.image)} 

--- a/components/StorageTool.tsx
+++ b/components/StorageTool.tsx
@@ -34,7 +34,7 @@ export default function StorageTool({ pageContent, questions, initialSelectedAns
             <section className="content-wrapper py-24 px-8 bg-neutral-50">
                 <SectionHeader title="Compare Storage Options" align="center" />
                 <div className="flex px-8 flex-col items-start pb-8">
-                    <h2 className="text-2xl font-bold text-gray-800 mx-12 my-12">{pageContent?.storage_tool_header}</h2>
+                    <h2 className="text-2xl font-bold text-gray-800 mx-36 px-24 my-12">{pageContent?.storage_tool_header}</h2>
                     <div className="w-full mt-0 flex flex-col xl:flex-row gap-4">
                         <div>
                             <Form

--- a/content/about/us.yaml
+++ b/content/about/us.yaml
@@ -1,408 +1,409 @@
-- name: Ashok Ragavendran
-  type: Full Time
-  team: Leadership
-  subteam: Computational Biology Core
-  title: Associate Director of Computational Biology and Data Science
-  github_username: ashokrags
-  brown_directory_uuid: 60802d0b-8f18-499a-a1f3-5f9b24c390e4
-  bio:
-    Ashok is a computational biologist/data scientist with a varied background
-    in genetics, genomics, statistics and computation. He has a PhD in Fisheries and
-    Wildlife from MSU and has worked in areas of quantitative genetics, biomedical genetics,
-    ecology and bioinformatics. Above all he has a keen interest in data analysis,
-    computing and providing user friendly solutions for analysis and visualization
-    of large data sets. Otherwise he keeps busy with two boys, two pups and life near
-    the beach.
-  image: ashok_main.jpg
-- name: Isabel Restrepo
-  type: Full Time
-  team: Leadership
-  subteam: Graphics, Software, and Data Core
-  title: Associate Director of Research Software Engineering and Data Science
-  github_username: mirestrepo
-  brown_directory_uuid: cb8b0a49-ef4b-66e7-5ccc-6689493e8ace
-  bio:
-    Isabel grew up in Colombia and received her Ph.D from Brown in 2013 in Electrical
-    Engineering with a focus in Computer Vision. She enjoys machine learning, reproducible
-    science, reverse engineering, playing squash, the sea, and dancing with her wild
-    children.
-  image: isabel_main.jpg
-- name: Linnea Wolfe
-  type: Full Time
-  team: Leadership
-  title: Assistant Chief Information Officer, Infrastructure and Research Computing
-  github_username: ""
-  brown_directory_uuid: 3ddfe2bd-672a-0f09-03bc-cbb37339a434
-  bio: ""
-  image: linnea_main.jpg
-- name: Paul Stey
-  type: Full Time
-  team: Leadership
-  title: Assistant CIO Research Software Engineering and Data Science
-  github_username: paulstey
-  brown_directory_uuid: 0525f19f-d156-4c47-a2e1-8b4e904a2e84
-  bio:
-    Paul is a data scientist interested in using data and machine learning to solve
-    challenging problems. Before coming to Brown he was a statistician at the EPA.
-    He has a PhD in Developmental Psychology.
-  image: stey_main.jpg
-- name: Sam Fulcomer
-  type: Full Time
-  team: Leadership
-  title: HPC IT Architect
-  github_username: ""
-  brown_directory_uuid: 0d83d4b5-85a5-62fc-44a3-81eaff49e183
-  bio: ""
-  image: fulcomer_main.jpg
-- name: Thomas Serre
-  type: Full Time
-  team: Leadership
-  title: Faculty Director, Professor of Cognitive, Linguistic, and Psychological Sciences
-  github_username: tserre
-  brown_directory_uuid: 9517d64b-6924-1c56-1f7e-2452b2304030
-  bio: Dr. Serre is a Professor in the Cognitive Linguistic & Psychological
-    Sciences at Brown University. Dr. Serre is a computational neuroscientist by training.
-    He received a Ph.D. in Neuroscience from MIT in 2006 and an MSc in EECS from Télécom
-    Bretagne (France) in 2000.
-  image: thomas_main.jpg
-- name: David D Johnson
-  type: Full Time
-  team: CCV Operations
-  subteam: High-Performance Computing Systems
-  title: Senior HPC Systems Engineer
-  github_username: ""
-  brown_directory_uuid: c14eb6ba-4b51-aabd-bf11-ef4071826060
-  bio: ""
-  image: dave_main.jpg
-- name: Geoffrey Avila
-  type: Full Time
-  team: CCV Operations
-  subteam: High-Performance Computing Systems
-  title: Senior HPC Systems Engineer
-  github_username: ""
-  brown_directory_uuid: f904bb23-202f-48fb-bf93-7b7d326c7043
-  image: avila_main.jpg
-- name: Nathan Wood
-  type: Full Time
-  team: CCV Operations
-  subteam: High-Performance Computing Systems
-  title: Senior Research Systems Administrator
-  github_username: n8wood-brown
-  brown_directory_uuid: 857b928c-2ce1-fb2a-cde7-1a4ff21fa2d3
-  bio: ""
-  image: nate_main.jpg
-- name: Jarrod Winsor
-  type: Full Time
-  team: CCV Operations
-  title: Lead Research Systems Administrator
-  github_username:
-  brown_directory_uuid: 1b81a653-ade8-4850-97ea-682644b714d0
-  bio: ""
-  image: jarrod_main.png
-- name: Timothy Poli
-  type: Full Time
-  team: CCV Operations
-  title: Senior Research Systems Administrator
-  github_username: ""
-  brown_directory_uuid: 6ad65e2c-ba76-358a-dd69-9ab5508b3d8b
-  bio: ""
-  image: timothy_main.png
-- name: Michael Antonelli
-  type: Full Time
-  team: CCV Operations
-  title: Research Systems Administrator
-  github_username: ""
-  brown_directory_uuid: ddb582f2-d4fd-4d8a-adf1-4c4e37902ddd
-  bio: ""
-  image: michael_main.png
-- name: Paul Koussa
-  type: Full Time
-  team: Leadership
-  title: Associate Director of Research Systems
-  github_username: ""
-  brown_directory_uuid: c67a6c91-53f3-3502-8fcb-006770f4d76e
-  bio: ""
-  image: koussa_main.png
-- name: Paulo S Baptista
-  type: Full Time
-  team: CCV Operations
-  subteam: High-Performance Computing Systems
-  title: Senior Research Systems Administrator
-  github_username: paulobaptista
-  brown_directory_uuid: 6e74d82d-bce5-0512-4ba0-f91ff313675a
-  bio: ""
-  image: paulo_main.jpg
-- name: Yang Liu
-  type: Full Time
-  team: CCV Operations
-  subteam: Research Technical Services
-  title: Assistant Director Research Computing Services 
-  github_username: yangliu2009
-  brown_directory_uuid: e0e55df3-9f2c-4a12-a1de-742955164e1e
-  bio:
-  image: yang_main.jpg
-- name: Prasad Bandarkar
-  type: Full Time
-  team: CCV Operations
-  subteam: Research Technical Services
-  title: Senior Research Computing Consultant 
-  github_username: prasadbandarkar
-  brown_directory_uuid: 11533980-c5cd-4969-81ca-537543da9b72
-  bio:
-  image: prasad_main.jpg
-- name: August Guang
-  type: Full Time
-  team: Advanced Research Computing
-  subteam: Computational Biology Core
-  title: Lead Genomics Data Scientist
-  github_username: aguang
-  brown_directory_uuid: b3f2991e-b618-190f-881f-25fc21f82d02
-  bio:
-    August obtained their PhD from Brown in 2017 in Applied Mathematics and Computational
-    Biology. Outside of work they organize against criminalization and the police
-    state. Both their research practices and organizing work are guided by the belief
-    that crisis and uncertainty are a gift and that we must be involved in shaping
-    how change happens.
-  image: august_main.jpg
-- name: Paul Cao
-  type: Full Time
-  team: Advanced Research Computing
-  title: Genomics Data Scientist
-  subteam: Computational Biology Core
-  github_username: paulcao-brown
-  brown_directory_uuid: ec11f732-efa0-4fa8-9cd2-030b45cb2929
-  bio: ""
-  image: cao_main.png
-- name: Jordan Lawson
-  type: Full Time
-  team: Advanced Research Computing
-  title: Senior Research Software Engineer
-  subteam: Computational Biology Core
-  github_username: j-stat
-  brown_directory_uuid: 44dc2e77-eaaf-4884-ace2-e3fbb57e58ea
-  bio:
-    Jordan is a Research Software Engineer in the Computational Biology Core at CCV.
-    He did his Ph.D. in Applied Statistics at Boston College, with an emphasis on causal inference. He
-    loves learning about natural and formal languages, superhero movies, boxing, and basketball.
-  image: jordan_main.jpg
-- name: Joselynn Wallace
-  type: Full Time
-  team: Advanced Research Computing
-  title: Senior Genomics Data Scientist
-  subteam: Computational Biology Core
-  github_username: jrwallace
-  brown_directory_uuid: 1eb864be-02d2-4880-a43f-62076e2d7366
-  bio:
-    Joselynn is a genomics data scientist. Before coming to Brown, she got her
-    PhD from the University of Rhode Island. Her background is primarily in studying
-    microbes.
-  image: joselynn_main.jpg
-- name: Ashley S. Lee
-  type: Full Time
-  team: Advanced Research Computing
-  subteam: Graphics, Software, and Data Core
-  title: Senior Research Software Engineer
-  github_username: ashleysyg
-  brown_directory_uuid: 380094e2-6f9d-47cf-91ce-e636876a58cf
-  bio: 
-    Ashley is a data scientist and software engineer. She studied at the 
-    University of Virginia Data Science Institute. Her range of experience is in 
-    machine learning, statistical analysis, data visualization, and web development projects in React. 
-    Her personal interests include muay thai, running, reading, thrifting, and dogs.
-  image: ashley_main.jpg
-- name: Bradford N. Roarr
-  type: Full Time
-  team: Advanced Research Computing
-  title: Lead Research Software Engineer
-  subteam: Graphics, Software, and Data Core
-  github_username: broarr
-  brown_directory_uuid: 0adf6ab4-8d56-410a-8ac6-4b4ca136a534
-  bio:
-    Bradford is a software engineer with a broad range of experience including
-    firmware engineering, devops, full-stack programming, and more. His professional
-    interests include systems programming, infrastructure-as-code, and automation.
-    Before Brown, Bradford worked for various startups in the Silicon Valley.
-  image: bradford_main.jpg
-- name: Camilo Diaz
-  type: Full Time
-  team: Advanced Research Computing
-  subteam: Graphics, Software, and Data Core
-  title: Senior Graphics/Visualization Software Engineer
-  github_username: kmilo9999
-  brown_directory_uuid: 448fac67-1dea-42ef-8205-9305ac9b79a6
-  bio:
-    Camilo is a software engineer who specializes in realtime simulation engines, 3D modeling and rendering, animations and VR technologies.
-    He loves learning programing languages and enjoys developing applications in multiple frameworks. Outside of work, he passes his time developing his own video games,
-    playing soccer and volunteering for multiple events accros Rhode Island.
-  image: camilo_main.jpg
-- name: Ellen Duong
-  type: Full Time
-  team: Advanced Research Computing
-  subteam: Graphics, Software, and Data Core
-  title: Lead Research Software Engineer
-  github_username: eldu
-  brown_directory_uuid: 1dee85fb-a5e4-474d-9f5e-ebef7d9d5ab7
-  bio: ""
-  image: ellen_main.jpg
-- name: Paul Xu
-  type: Full Time
-  team: Advanced Research Computing
-  subteam: Graphics, Software, and Data Core
-  title: Lead Data Scientist
-  github_username: digicosmos86
-  brown_directory_uuid: 58724daa-f619-4f86-88f0-30635dc5178b
-  bio: Paul's diverse interests as a Lead Data Scientist include building generative AI applications in computer vision and natural language processing, engineering data science software, and maintaining cloud compute infrastructure for data science. Paul received his Sc.M. in Computer Science with focus on AI/ML from Brown University and Ph.D. in Curriculum and Instruction with focus on CS Education from Boston College. In his own time, Paul likes to geek out on computer and natural languages. He is also an avid photographer with his work published in an international magazine.
-  image: px_main.jpg
-- name: Joshua Lu
-  type: Full Time
-  team: Advanced Research Computing
-  subteam: Graphics, Software, and Data Core
-  title: Research Software Engineer
-  github_username: jashlu
-  brown_directory_uuid: 534e9bc2-bf24-444f-a568-710c0193c2ec
-  bio: ""
-  image: joshua_main.png
-- name: Robert Gemma, Jr.
-  type: Full Time
-  team: Advanced Research Computing
-  subteam: Graphics, Software, and Data Core
-  title: Research Software Engineer
-  github_username: RobertGemmaJr
-  brown_directory_uuid: e78668ed-0e7a-4e5f-a69e-ab4a5015961c
-  bio:
-    Robert started his career as a software engineer here at the CCV. He is specially interested
-    in the intersection of XR technologies with science, data, art, and visualization. Robert
-    received his undergraduate degree in Computer Science from the University of Rhode Island
-    where he also minored in music.
-  image: robert_main.jpg
-- name: Paul Hall
-  type: Full Time
-  team: Advanced Research Computing
-  subteam: High-Performance Computing
-  title: Senior Research Software Engineer
-  github_username: phall-brown
-  brown_directory_uuid: da1c3aed-d801-56a8-0536-0701f6c5c830
-  bio:
-    Paul has a background in computational fluid dynamics and geophysics. He received
-    his Ph.D. in Oceanography from the URI.
-  image: hall_main.jpg
-- name: Timothy Divoll
-  type: Full Time
-  team: Advanced Research Computing
-  subteam: Graphics, Software, and Data Core
-  title: Senior Data Scientist
-  github_username: tdivoll
-  brown_directory_uuid: d98138f4-a49c-4e1b-9bc4-1832b51f6f46
-  bio:
-    Tim has dabbled in several aspects of data science such as computer vision for species detection,
-    bioinformatics for metabarcoding, and statistics for ecological inference. He studied the foraging
-    ecology of bats at Indiana State University for his PhD. Overall, he enjoys reproducible science
-    and making pipelines accessible.
-  image: tim_main.jpg
-- name: John Gerrard Holland
-  type: Full Time
-  team: Advanced Research Computing
-  subteam: Graphics, Software, and Data Core
-  title: Lead Data Scientist
-  github_username: hollandjg
-  brown_directory_uuid: c58cefc3-dc27-408f-ae62-fa098803341d
-  bio: John is a data scientist at the CCV, who is passionate about climate,
-    Earth observation and sustainability. Prior to starting at the CCV, John studied physics,
-    received his doctorate for research in astronomy,
-    and worked for a boutique management and IT consultancy in Germany.
-  image: john_main.jpg
-- name: Carlos Paniagua
-  type: Full Time
-  team: Advanced Research Computing
-  subteam: Graphics, Software, and Data Core
-  title: Senior Data Scientist
-  github_username: cpaniaguam
-  brown_directory_uuid: 504c3db1-c3ec-4b15-9350-704e8bbe3036
-  bio: Carlos is a data scientist at the CCV. Previously a Mathematics tenure-track faculty member at universities in the US and the Dominican Republic, Carlos likes using his skills working with data for wider social impact.
-  image: carlos_main.jpg
-- name: George Dang
-  type: Full Time
-  team: Advanced Research Computing
-  subteam: Graphics, Software, and Data Core
-  title: Senior Data Scientist
-  github_username: gtdang
-  brown_directory_uuid: d91b1633-1534-41ab-b38d-78a23e99d843
-  bio:
-    George is a data scientist with a background in biology and environmental science.
-    Prior to joining CCV, worked in environmental consulting specializing in water quality and geospatial analytics.
-  image: dang_main.jpg
-- name: Ford McDonald
-  type: Full Time
-  team: Advanced Research Computing
-  subteam: Graphics, Software, and Data Core
-  title: Research Software Engineer
-  github_username: fordmcdonald
-  brown_directory_uuid: c694e24f-287d-4816-9f96-2753568d085c
-  bio: Ford is a software engineer here at CCV, with a background in simulation-based prototyping and user interface development. His favorite weekend ventures include hiking a new trail in the White Mountains, or heading down to Narragansett Beach for a surf.
-  image: ford_main.jpg
-- name: Eric Salomaki
-  type: Full Time
-  team: Advanced Research Computing
-  subteam: Computational Biology Core
-  title: Senior Genomics Data Scientist
-  github_username: EricSalomaki
-  brown_directory_uuid: 0b047bf7-47f2-4873-8eef-87d4d69aba98
-  bio: Eric is a genomics data scientist at the CCV. Before coming to Brown, he was a postdoc investigating genome evolution, organellar metabolism, and biodiversity of protists at the Czech Academy of Sciences. He earned his PhD from the University of Rhode Island studying the evolution of parasitism in red algae.
-  image: eric_main.jpg
-- name: Heather Yu
-  type: Full Time
-  team: Advanced Research Computing
-  subteam: Graphics, Software, and Data Core
-  title: Research Software Engineer
-  github_username: hetd54
-  brown_directory_uuid: 347df47c-4a2d-4c43-b6f9-3e88c8a5c146
-  bio: Heather is a research software engineer with a background in research applications and database creation. Prior to joining CCV, she was a Research Manager at Brown in the Department of Cognitive, Linguistic, and Psychological Sciences (CLPS).
-  image: heather_main.jpg
-- name: Anna Murphy
-  type: Full Time
-  team: Advanced Research Computing
-  subteam: Graphics, Software, and Data Core
-  title: Research Software Engineer
-  github_username: anna-murphy
-  brown_directory_uuid: 0b37438d-b5c2-41d6-9d87-14c446698a07
-  bio: Anna is a software engineer and researcher with the CCV with a background in full-stack web development. She loves thinking about technology and media, and the different impacts they both have on the world.
-  image: anna_main.jpg
-- name: Rain Fan
-  type: Full Time
-  team: CCV Operations
-  subteam: Research Technical Services
-  title: Research Computing Consultant
-  github_username: rainxfan
-  brown_directory_uuid: D5bc11b8-b031-4402-8f40-d08ccee18b60
-  bio:
-  image: rain_main.jpg
-- name: Prithvi Thakur
-  type: Full Time
-  team: Advanced Research Computing
-  subteam: High-Performance Computing
-  title: Research Software Engineer
-  github_username: thehalfspace
-  brown_directory_uuid: cb6e1744-8240-430c-89b5-0bd1cf78d0a3
-  bio: Prithvi is a research software engineer in the High Performance Computing division at CCV. He did his PhD in computational seismology from UMich, and later spent a year modeling extreme events and natural catastrophes at Karen Clark and Company. His professional interests include high performance computing, statistical modeling, software development, and earthquake source processes. Outside of work, you can find him hiking in the woods or playing music.
-  image: prithvi_main.jpg
-- name: Sam Bessey
-  type: Full Time
-  team: Advanced Research Computing
-  subteam: Graphics, Software, and Data Core
-  title: Research Software Engineer
-  github_username: s-bessey
-  brown_directory_uuid: 9788c813-f3f4-4b64-b8ac-2221a92886c2
-  bio: Sam has a background in environmental science and mathematical modeling
-    for epidemiology. Before coming to CCV, Sam worked at Brown's People, Place,
-    and Health Collective in the school of public health, where they developed
-    software to study the spread of HIV through sexual and needle-sharing networks.
-  image: sam_main.jpeg
-- name: Gurpartap Singh
-  type: Part Time
-  team: Advanced Research Computing
-  subteam: Graphics, Software, and Data Core
-  title: Web Developer Intern
-  github_username: gpsss246
-  brown_directory_uuid: bed03629-ed04-429d-af97-64fa7415d182
-  bio: Gurpartap Singh studies Computer Science and Political Science at Brown University as a member of the Class of 2026. You can find Gurpartap listening to music or learning how to create it (ask me about the Alan Turing Album). I make a good cup of Masala Cha so feel free to ask for a cup!
-  image: gurpartap_main.png
+people:
+  - name: Ashok Ragavendran
+    type: Full Time
+    team: Leadership
+    subteam: Computational Biology Core
+    title: Associate Director of Computational Biology and Data Science
+    github_username: ashokrags
+    brown_directory_uuid: 60802d0b-8f18-499a-a1f3-5f9b24c390e4
+    bio:
+      Ashok is a computational biologist/data scientist with a varied background
+      in genetics, genomics, statistics and computation. He has a PhD in Fisheries and
+      Wildlife from MSU and has worked in areas of quantitative genetics, biomedical genetics,
+      ecology and bioinformatics. Above all he has a keen interest in data analysis,
+      computing and providing user friendly solutions for analysis and visualization
+      of large data sets. Otherwise he keeps busy with two boys, two pups and life near
+      the beach.
+    image: ashok_main.jpg
+  - name: Isabel Restrepo
+    type: Full Time
+    team: Leadership
+    subteam: Graphics, Software, and Data Core
+    title: Associate Director of Research Software Engineering and Data Science
+    github_username: mirestrepo
+    brown_directory_uuid: cb8b0a49-ef4b-66e7-5ccc-6689493e8ace
+    bio:
+      Isabel grew up in Colombia and received her Ph.D from Brown in 2013 in Electrical
+      Engineering with a focus in Computer Vision. She enjoys machine learning, reproducible
+      science, reverse engineering, playing squash, the sea, and dancing with her wild
+      children.
+    image: isabel_main.jpg
+  - name: Linnea Wolfe
+    type: Full Time
+    team: Leadership
+    title: Assistant Chief Information Officer, Infrastructure and Research Computing
+    github_username: ""
+    brown_directory_uuid: 3ddfe2bd-672a-0f09-03bc-cbb37339a434
+    bio: ""
+    image: linnea_main.jpg
+  - name: Paul Stey
+    type: Full Time
+    team: Leadership
+    title: Assistant CIO Research Software Engineering and Data Science
+    github_username: paulstey
+    brown_directory_uuid: 0525f19f-d156-4c47-a2e1-8b4e904a2e84
+    bio:
+      Paul is a data scientist interested in using data and machine learning to solve
+      challenging problems. Before coming to Brown he was a statistician at the EPA.
+      He has a PhD in Developmental Psychology.
+    image: stey_main.jpg
+  - name: Sam Fulcomer
+    type: Full Time
+    team: Leadership
+    title: HPC IT Architect
+    github_username: ""
+    brown_directory_uuid: 0d83d4b5-85a5-62fc-44a3-81eaff49e183
+    bio: ""
+    image: fulcomer_main.jpg
+  - name: Thomas Serre
+    type: Full Time
+    team: Leadership
+    title: Faculty Director, Professor of Cognitive, Linguistic, and Psychological Sciences
+    github_username: tserre
+    brown_directory_uuid: 9517d64b-6924-1c56-1f7e-2452b2304030
+    bio: Dr. Serre is a Professor in the Cognitive Linguistic & Psychological
+      Sciences at Brown University. Dr. Serre is a computational neuroscientist by training.
+      He received a Ph.D. in Neuroscience from MIT in 2006 and an MSc in EECS from Télécom
+      Bretagne (France) in 2000.
+    image: thomas_main.jpg
+  - name: David D Johnson
+    type: Full Time
+    team: CCV Operations
+    subteam: High-Performance Computing Systems
+    title: Senior HPC Systems Engineer
+    github_username: ""
+    brown_directory_uuid: c14eb6ba-4b51-aabd-bf11-ef4071826060
+    bio: ""
+    image: dave_main.jpg
+  - name: Geoffrey Avila
+    type: Full Time
+    team: CCV Operations
+    subteam: High-Performance Computing Systems
+    title: Senior HPC Systems Engineer
+    github_username: ""
+    brown_directory_uuid: f904bb23-202f-48fb-bf93-7b7d326c7043
+    image: avila_main.jpg
+  - name: Nathan Wood
+    type: Full Time
+    team: CCV Operations
+    subteam: High-Performance Computing Systems
+    title: Senior Research Systems Administrator
+    github_username: n8wood-brown
+    brown_directory_uuid: 857b928c-2ce1-fb2a-cde7-1a4ff21fa2d3
+    bio: ""
+    image: nate_main.jpg
+  - name: Jarrod Winsor
+    type: Full Time
+    team: CCV Operations
+    title: Lead Research Systems Administrator
+    github_username:
+    brown_directory_uuid: 1b81a653-ade8-4850-97ea-682644b714d0
+    bio: ""
+    image: jarrod_main.png
+  - name: Timothy Poli
+    type: Full Time
+    team: CCV Operations
+    title: Senior Research Systems Administrator
+    github_username: ""
+    brown_directory_uuid: 6ad65e2c-ba76-358a-dd69-9ab5508b3d8b
+    bio: ""
+    image: timothy_main.png
+  - name: Michael Antonelli
+    type: Full Time
+    team: CCV Operations
+    title: Research Systems Administrator
+    github_username: ""
+    brown_directory_uuid: ddb582f2-d4fd-4d8a-adf1-4c4e37902ddd
+    bio: ""
+    image: michael_main.png
+  - name: Paul Koussa
+    type: Full Time
+    team: Leadership
+    title: Associate Director of Research Systems
+    github_username: ""
+    brown_directory_uuid: c67a6c91-53f3-3502-8fcb-006770f4d76e
+    bio: ""
+    image: koussa_main.png
+  - name: Paulo S Baptista
+    type: Full Time
+    team: CCV Operations
+    subteam: High-Performance Computing Systems
+    title: Senior Research Systems Administrator
+    github_username: paulobaptista
+    brown_directory_uuid: 6e74d82d-bce5-0512-4ba0-f91ff313675a
+    bio: ""
+    image: paulo_main.jpg
+  - name: Yang Liu
+    type: Full Time
+    team: CCV Operations
+    subteam: Research Technical Services
+    title: Assistant Director Research Computing Services 
+    github_username: yangliu2009
+    brown_directory_uuid: e0e55df3-9f2c-4a12-a1de-742955164e1e
+    bio:
+    image: yang_main.jpg
+  - name: Prasad Bandarkar
+    type: Full Time
+    team: CCV Operations
+    subteam: Research Technical Services
+    title: Senior Research Computing Consultant 
+    github_username: prasadbandarkar
+    brown_directory_uuid: 11533980-c5cd-4969-81ca-537543da9b72
+    bio:
+    image: prasad_main.jpg
+  - name: August Guang
+    type: Full Time
+    team: Advanced Research Computing
+    subteam: Computational Biology Core
+    title: Lead Genomics Data Scientist
+    github_username: aguang
+    brown_directory_uuid: b3f2991e-b618-190f-881f-25fc21f82d02
+    bio:
+      August obtained their PhD from Brown in 2017 in Applied Mathematics and Computational
+      Biology. Outside of work they organize against criminalization and the police
+      state. Both their research practices and organizing work are guided by the belief
+      that crisis and uncertainty are a gift and that we must be involved in shaping
+      how change happens.
+    image: august_main.jpg
+  - name: Paul Cao
+    type: Full Time
+    team: Advanced Research Computing
+    title: Genomics Data Scientist
+    subteam: Computational Biology Core
+    github_username: paulcao-brown
+    brown_directory_uuid: ec11f732-efa0-4fa8-9cd2-030b45cb2929
+    bio: ""
+    image: cao_main.png
+  - name: Jordan Lawson
+    type: Full Time
+    team: Advanced Research Computing
+    title: Senior Research Software Engineer
+    subteam: Computational Biology Core
+    github_username: j-stat
+    brown_directory_uuid: 44dc2e77-eaaf-4884-ace2-e3fbb57e58ea
+    bio:
+      Jordan is a Research Software Engineer in the Computational Biology Core at CCV.
+      He did his Ph.D. in Applied Statistics at Boston College, with an emphasis on causal inference. He
+      loves learning about natural and formal languages, superhero movies, boxing, and basketball.
+    image: jordan_main.jpg
+  - name: Joselynn Wallace
+    type: Full Time
+    team: Advanced Research Computing
+    title: Senior Genomics Data Scientist
+    subteam: Computational Biology Core
+    github_username: jrwallace
+    brown_directory_uuid: 1eb864be-02d2-4880-a43f-62076e2d7366
+    bio:
+      Joselynn is a genomics data scientist. Before coming to Brown, she got her
+      PhD from the University of Rhode Island. Her background is primarily in studying
+      microbes.
+    image: joselynn_main.jpg
+  - name: Ashley S. Lee
+    type: Full Time
+    team: Advanced Research Computing
+    subteam: Graphics, Software, and Data Core
+    title: Senior Research Software Engineer
+    github_username: ashleysyg
+    brown_directory_uuid: 380094e2-6f9d-47cf-91ce-e636876a58cf
+    bio: 
+      Ashley is a data scientist and software engineer. She studied at the 
+      University of Virginia Data Science Institute. Her range of experience is in 
+      machine learning, statistical analysis, data visualization, and web development projects in React. 
+      Her personal interests include muay thai, running, reading, thrifting, and dogs.
+    image: ashley_main.jpg
+  - name: Bradford N. Roarr
+    type: Full Time
+    team: Advanced Research Computing
+    title: Lead Research Software Engineer
+    subteam: Graphics, Software, and Data Core
+    github_username: broarr
+    brown_directory_uuid: 0adf6ab4-8d56-410a-8ac6-4b4ca136a534
+    bio:
+      Bradford is a software engineer with a broad range of experience including
+      firmware engineering, devops, full-stack programming, and more. His professional
+      interests include systems programming, infrastructure-as-code, and automation.
+      Before Brown, Bradford worked for various startups in the Silicon Valley.
+    image: bradford_main.jpg
+  - name: Camilo Diaz
+    type: Full Time
+    team: Advanced Research Computing
+    subteam: Graphics, Software, and Data Core
+    title: Senior Graphics/Visualization Software Engineer
+    github_username: kmilo9999
+    brown_directory_uuid: 448fac67-1dea-42ef-8205-9305ac9b79a6
+    bio:
+      Camilo is a software engineer who specializes in realtime simulation engines, 3D modeling and rendering, animations and VR technologies.
+      He loves learning programing languages and enjoys developing applications in multiple frameworks. Outside of work, he passes his time developing his own video games,
+      playing soccer and volunteering for multiple events accros Rhode Island.
+    image: camilo_main.jpg
+  - name: Ellen Duong
+    type: Full Time
+    team: Advanced Research Computing
+    subteam: Graphics, Software, and Data Core
+    title: Lead Research Software Engineer
+    github_username: eldu
+    brown_directory_uuid: 1dee85fb-a5e4-474d-9f5e-ebef7d9d5ab7
+    bio: ""
+    image: ellen_main.jpg
+  - name: Paul Xu
+    type: Full Time
+    team: Advanced Research Computing
+    subteam: Graphics, Software, and Data Core
+    title: Lead Data Scientist
+    github_username: digicosmos86
+    brown_directory_uuid: 58724daa-f619-4f86-88f0-30635dc5178b
+    bio: Paul's diverse interests as a Lead Data Scientist include building generative AI applications in computer vision and natural language processing, engineering data science software, and maintaining cloud compute infrastructure for data science. Paul received his Sc.M. in Computer Science with focus on AI/ML from Brown University and Ph.D. in Curriculum and Instruction with focus on CS Education from Boston College. In his own time, Paul likes to geek out on computer and natural languages. He is also an avid photographer with his work published in an international magazine.
+    image: px_main.jpg
+  - name: Joshua Lu
+    type: Full Time
+    team: Advanced Research Computing
+    subteam: Graphics, Software, and Data Core
+    title: Research Software Engineer
+    github_username: jashlu
+    brown_directory_uuid: 534e9bc2-bf24-444f-a568-710c0193c2ec
+    bio: ""
+    image: joshua_main.png
+  - name: Robert Gemma, Jr.
+    type: Full Time
+    team: Advanced Research Computing
+    subteam: Graphics, Software, and Data Core
+    title: Research Software Engineer
+    github_username: RobertGemmaJr
+    brown_directory_uuid: e78668ed-0e7a-4e5f-a69e-ab4a5015961c
+    bio:
+      Robert started his career as a software engineer here at the CCV. He is specially interested
+      in the intersection of XR technologies with science, data, art, and visualization. Robert
+      received his undergraduate degree in Computer Science from the University of Rhode Island
+      where he also minored in music.
+    image: robert_main.jpg
+  - name: Paul Hall
+    type: Full Time
+    team: Advanced Research Computing
+    subteam: High-Performance Computing
+    title: Senior Research Software Engineer
+    github_username: phall-brown
+    brown_directory_uuid: da1c3aed-d801-56a8-0536-0701f6c5c830
+    bio:
+      Paul has a background in computational fluid dynamics and geophysics. He received
+      his Ph.D. in Oceanography from the URI.
+    image: hall_main.jpg
+  - name: Timothy Divoll
+    type: Full Time
+    team: Advanced Research Computing
+    subteam: Graphics, Software, and Data Core
+    title: Senior Data Scientist
+    github_username: tdivoll
+    brown_directory_uuid: d98138f4-a49c-4e1b-9bc4-1832b51f6f46
+    bio:
+      Tim has dabbled in several aspects of data science such as computer vision for species detection,
+      bioinformatics for metabarcoding, and statistics for ecological inference. He studied the foraging
+      ecology of bats at Indiana State University for his PhD. Overall, he enjoys reproducible science
+      and making pipelines accessible.
+    image: tim_main.jpg
+  - name: John Gerrard Holland
+    type: Full Time
+    team: Advanced Research Computing
+    subteam: Graphics, Software, and Data Core
+    title: Lead Data Scientist
+    github_username: hollandjg
+    brown_directory_uuid: c58cefc3-dc27-408f-ae62-fa098803341d
+    bio: John is a data scientist at the CCV, who is passionate about climate,
+      Earth observation and sustainability. Prior to starting at the CCV, John studied physics,
+      received his doctorate for research in astronomy,
+      and worked for a boutique management and IT consultancy in Germany.
+    image: john_main.jpg
+  - name: Carlos Paniagua
+    type: Full Time
+    team: Advanced Research Computing
+    subteam: Graphics, Software, and Data Core
+    title: Senior Data Scientist
+    github_username: cpaniaguam
+    brown_directory_uuid: 504c3db1-c3ec-4b15-9350-704e8bbe3036
+    bio: Carlos is a data scientist at the CCV. Previously a Mathematics tenure-track faculty member at universities in the US and the Dominican Republic, Carlos likes using his skills working with data for wider social impact.
+    image: carlos_main.jpg
+  - name: George Dang
+    type: Full Time
+    team: Advanced Research Computing
+    subteam: Graphics, Software, and Data Core
+    title: Senior Data Scientist
+    github_username: gtdang
+    brown_directory_uuid: d91b1633-1534-41ab-b38d-78a23e99d843
+    bio:
+      George is a data scientist with a background in biology and environmental science.
+      Prior to joining CCV, worked in environmental consulting specializing in water quality and geospatial analytics.
+    image: dang_main.jpg
+  - name: Ford McDonald
+    type: Full Time
+    team: Advanced Research Computing
+    subteam: Graphics, Software, and Data Core
+    title: Research Software Engineer
+    github_username: fordmcdonald
+    brown_directory_uuid: c694e24f-287d-4816-9f96-2753568d085c
+    bio: Ford is a software engineer here at CCV, with a background in simulation-based prototyping and user interface development. His favorite weekend ventures include hiking a new trail in the White Mountains, or heading down to Narragansett Beach for a surf.
+    image: ford_main.jpg
+  - name: Eric Salomaki
+    type: Full Time
+    team: Advanced Research Computing
+    subteam: Computational Biology Core
+    title: Senior Genomics Data Scientist
+    github_username: EricSalomaki
+    brown_directory_uuid: 0b047bf7-47f2-4873-8eef-87d4d69aba98
+    bio: Eric is a genomics data scientist at the CCV. Before coming to Brown, he was a postdoc investigating genome evolution, organellar metabolism, and biodiversity of protists at the Czech Academy of Sciences. He earned his PhD from the University of Rhode Island studying the evolution of parasitism in red algae.
+    image: eric_main.jpg
+  - name: Heather Yu
+    type: Full Time
+    team: Advanced Research Computing
+    subteam: Graphics, Software, and Data Core
+    title: Research Software Engineer
+    github_username: hetd54
+    brown_directory_uuid: 347df47c-4a2d-4c43-b6f9-3e88c8a5c146
+    bio: Heather is a research software engineer with a background in research applications and database creation. Prior to joining CCV, she was a Research Manager at Brown in the Department of Cognitive, Linguistic, and Psychological Sciences (CLPS).
+    image: heather_main.jpg
+  - name: Anna Murphy
+    type: Full Time
+    team: Advanced Research Computing
+    subteam: Graphics, Software, and Data Core
+    title: Research Software Engineer
+    github_username: anna-murphy
+    brown_directory_uuid: 0b37438d-b5c2-41d6-9d87-14c446698a07
+    bio: Anna is a software engineer and researcher with the CCV with a background in full-stack web development. She loves thinking about technology and media, and the different impacts they both have on the world.
+    image: anna_main.jpg
+  - name: Rain Fan
+    type: Full Time
+    team: CCV Operations
+    subteam: Research Technical Services
+    title: Research Computing Consultant
+    github_username: rainxfan
+    brown_directory_uuid: D5bc11b8-b031-4402-8f40-d08ccee18b60
+    bio:
+    image: rain_main.jpg
+  - name: Prithvi Thakur
+    type: Full Time
+    team: Advanced Research Computing
+    subteam: High-Performance Computing
+    title: Research Software Engineer
+    github_username: thehalfspace
+    brown_directory_uuid: cb6e1744-8240-430c-89b5-0bd1cf78d0a3
+    bio: Prithvi is a research software engineer in the High Performance Computing division at CCV. He did his PhD in computational seismology from UMich, and later spent a year modeling extreme events and natural catastrophes at Karen Clark and Company. His professional interests include high performance computing, statistical modeling, software development, and earthquake source processes. Outside of work, you can find him hiking in the woods or playing music.
+    image: prithvi_main.jpg
+  - name: Sam Bessey
+    type: Full Time
+    team: Advanced Research Computing
+    subteam: Graphics, Software, and Data Core
+    title: Research Software Engineer
+    github_username: s-bessey
+    brown_directory_uuid: 9788c813-f3f4-4b64-b8ac-2221a92886c2
+    bio: Sam has a background in environmental science and mathematical modeling
+      for epidemiology. Before coming to CCV, Sam worked at Brown's People, Place,
+      and Health Collective in the school of public health, where they developed
+      software to study the spread of HIV through sexual and needle-sharing networks.
+    image: sam_main.jpeg
+  - name: Gurpartap Singh
+    type: Part Time
+    team: Advanced Research Computing
+    subteam: Graphics, Software, and Data Core
+    title: Web Developer Intern
+    github_username: gpsss246
+    brown_directory_uuid: bed03629-ed04-429d-af97-64fa7415d182
+    bio: Gurpartap Singh studies Computer Science and Political Science at Brown University as a member of the Class of 2026. You can find Gurpartap listening to music or learning how to create it (ask me about the Alan Turing Album). I make a good cup of Masala Cha so feel free to ask for a cup!
+    image: gurpartap_main.png

--- a/content/services/storage/storage-tool.yaml
+++ b/content/services/storage/storage-tool.yaml
@@ -11,8 +11,8 @@ call-for-action:
 
 storage_tool_header: |
   This tool lets you compare the available storage options at Brown.
-  Answer some of these questions or select services to compare their features
-  and decide which of these services suit your needs.
+  Answer the questions in the form to compare their features
+  and decide which of these services best suits your needs. Select a storage service in the table for more information about the service.
 
 services:
   - name: "Google Drive"

--- a/lib/about-types.ts
+++ b/lib/about-types.ts
@@ -1,0 +1,36 @@
+// --- about/us
+export interface PeopleTypes{
+  name: string;
+  type: string;
+  team: string;
+  subteam: string;
+  title: string;
+  github_username: string;
+  brown_directory_uuid: string;
+  bio: string;
+  image: string;
+}
+
+// --- about/contact
+export interface ContactUsTypes {
+  title: string;
+  icon?: string;
+  description: string;
+  buttonLinks?: { text: string; href: string }[];
+}
+
+export interface OfficeHoursTypes {
+  title: string;
+  subtitle: string;
+  description: string;
+  buttonLinks?: { text: string; href: string }[];
+}
+
+// --- generic
+export interface PageContentData {
+    title?: string;
+    description?: string;
+    contactUs: ContactUsTypes[];
+    officeHours: OfficeHoursTypes[];
+    people: PeopleTypes[];
+  }

--- a/lib/content-utils.ts
+++ b/lib/content-utils.ts
@@ -3,58 +3,90 @@ import path from 'path';
 import matter from 'front-matter';
 import MarkdownIt from 'markdown-it';
 import * as yaml from 'js-yaml';
-import { PageContentData } from '@/lib/storage-types';
+
+interface ParsedMarkdownContent<TData> {
+  data: TData;
+  content: string;
+}
+
+interface ParsedYamlContent<TData> {
+  data: TData;
+  content: '';
+}
 
 const md = new MarkdownIt();
 
-// define diff md/yaml return structures so typescript knows the return can be diff shapes
-interface ParsedMarkdownContent {
-  data: Record<string, any>;
-  content: string;
+/**
+ * Reads and parses a content file (.md or .yaml/.yml).
+ * Throws an error for unsupported file types.
+ *
+ * @param filePath The absolute path to the content file.
+ * @returns A promise resolving to either ParsedMarkdownContent or ParsedYamlContent,
+ * where TData is the expected structure of the file's content/frontmatter.
+ * @throws {Error} If the file type is unsupported or reading/parsing fails.
+ */
+export async function readContentFile<TData>(
+  filePath: string
+): Promise<ParsedMarkdownContent<TData> | ParsedYamlContent<TData>> {
+  const fileContent = await fs.readFile(filePath, 'utf8');
+  const extension = path.extname(filePath).toLowerCase();
+
+  if (extension === '.md') {
+    const parsed = matter(fileContent);
+    return {
+      data: (parsed.attributes || {}) as TData,
+      content: md.render(parsed.body)
+    } as ParsedMarkdownContent<TData>;
+  } else if (extension === '.yaml' || extension === '.yml') {
+    const parsedYaml = yaml.load(fileContent);
+    return {
+      data: parsedYaml as TData,
+      content: ''
+    } as ParsedYamlContent<TData>;
+  }
+
+  throw new Error(`Unsupported file type encountered: ${extension} for file ${filePath}`);
 }
 
-interface ParsedYamlContent {
-  data: PageContentData; 
-  content: string;
-}
-
-export async function readContentFile(filePath: string): Promise<ParsedMarkdownContent | ParsedYamlContent | undefined> {
-    const fileContent = await fs.readFile(filePath, 'utf8');
-    const extension = path.extname(filePath).toLowerCase();
-
-    if (extension === '.md') {
-        const parsed = matter(fileContent);
-        return { data: (parsed.attributes || {}) as Record<string, any>, content: md.render(parsed.body) };
-    } else if (extension === '.yaml' || extension === '.yml') {
-        const parsedYaml = yaml.load(fileContent); // js-yaml.load returns 'unknown' or 'any' by default
-        return { data: parsedYaml as PageContentData, content: '' };
-    }
-    console.warn(`Unsupported file type encountered: ${extension} for file ${filePath}`);
-    return undefined;
-}
-
-export async function readContentFolder(contentFolder: string) {
+/**
+ * Reads and parses all content files in a specified folder.
+ * Filters out any files that cause errors or are of unsupported types.
+ *
+ * @param contentFolder The name of the subfolder within 'content' (e.g., 'about', 'storage').
+ * @returns A promise resolving to an array of parsed content objects,
+ * where TData is the expected structure for files in this folder.
+ */
+export async function readContentFolder<TData>(
+  contentFolder: string
+): Promise<{ slug: string; data: TData; content: string }[]> {
   const folderPath = path.join(process.cwd(), 'content', contentFolder);
   const filenames = await fs.readdir(folderPath);
 
-  const results = await Promise.all(
+  const results = await Promise.allSettled(
     filenames.map(async (filename) => {
       const filePath = path.join(folderPath, filename);
-      const parsed = await readContentFile(filePath);
       const extension = path.extname(filename).toLowerCase();
       const slug = filename.replace(/\.(md|yaml|yml)$/, '');
 
-      if (parsed) {
+      try {
+        const parsed = await readContentFile<TData>(filePath);
+
         if (extension === '.md') {
           return { slug, data: parsed.data, content: parsed.content };
         } else if (extension === '.yaml' || extension === '.yml') {
           return { slug, data: parsed.data, content: '' };
         }
+        console.warn(`Unexpected file type in folder: ${extension} for file ${filePath}`);
+        return null;
+      } catch (error) {
+        console.error(`Error processing file ${filePath}:`, error instanceof Error ? error.message : error);
+        return null;
       }
-      return undefined;
     })
   );
-  // filter out undefined results... the final cast assumes all valid files in the folder result in PageContentData,
-  // which might need adjustment if your folder contains a mix of YAML (PageContentData) and other Markdown files.
-  return results.filter(Boolean) as ({ slug: string; data: PageContentData; content: string })[];
+
+  return results
+    .filter((result): result is PromiseFulfilledResult<{ slug: string; data: TData; content: string } | null> => result.status === 'fulfilled')
+    .map(result => result.value)
+    .filter(Boolean) as ({ slug: string; data: TData; content: string })[];
 }


### PR DESCRIPTION
This PR makes a PageContentData for each subroute (storage, about, etc). It also updates the content-utils to assume that the content folder will never have non yaml/yml/md files