### PR TITLE
Feat(storage):  services header routing

### DIFF
--- a/app/services/storage/page.tsx
+++ b/app/services/storage/page.tsx
@@ -61,7 +61,7 @@ export default async function Storage() {
           const sectionBgColor = isEven ? 'bg-white' : 'bg-neutral-50';
 
           return(
-            <section key={serviceSection.name} id={serviceSection.name} className={`${sectionBgColor} py-16 sm:py-24 mb-12`} >
+            <section key={serviceSection.name} id={serviceSection.name} className={`${sectionBgColor} py-16 sm:py-24 `} >
               <div className="px-14 lg:px-36">
               <SectionHeader title={humanize(serviceSection.name)} align="center" />
               <Card className="w-full border-none shadow-none rounded-none">

--- a/components/StorageTable.tsx
+++ b/components/StorageTable.tsx
@@ -3,6 +3,7 @@ import { cn, humanize } from '@/lib/utils';
 import Markdown from 'react-markdown';
 import rehypeRaw from 'rehype-raw'
 import remarkGfm from 'remark-gfm'
+import Link from 'next/link'
 import { ServiceConfig, SelectedAnswers, TableRow, QuestionsConfig, ServiceFeature, featureIcons, featureColorMap  } from '@/lib/storage-types'
 import {
   createColumnHelper,
@@ -125,9 +126,9 @@ const tableData: TableRow[] = useMemo(() => {
       return columnHelper.accessor(service.name, {
         id: service.name,
         header: () => (
-          <div className={cn("flex flex-col items-start justify-start text-center px-2 py-2", columnClass)}>
+          <Link href={`/services/storage#${service.name}`} className={cn("flex flex-col items-start justify-start text-center px-2 py-2", columnClass)}>
             <div className="font-semibold">{humanize(service.name)}</div>
-          </div>
+          </Link>
         ),
         cell: info => {
           const feature = info.getValue() as ServiceFeature;

--- a/components/StorageTable.tsx
+++ b/components/StorageTable.tsx
@@ -134,6 +134,15 @@ const tableData: TableRow[] = useMemo(() => {
           const feature = info.getValue() as ServiceFeature;
           const featureNameFromRow = info.row.original.featureName;
           const cellContentClasses = cn("px-4 py-2 text-start", columnClass);
+
+          if (feature === undefined) {
+            return (
+              <div className={cn("flex flex-col items-center justify-center p-2 min-h-[80px]", cellContentClasses)}>
+                <span className="text-neutral-400 text-3xl">-</span>
+              </div>
+            );
+          }
+
           const featureClassLower = String(feature?.value).toLowerCase();
           const IconComponent = featureIcons[featureNameFromRow.toLowerCase()];
           const valueColor = featureColorMap[featureClassLower] || featureColorMap['default'];
@@ -203,12 +212,13 @@ const tableData: TableRow[] = useMemo(() => {
           <thead className="bg-white">
             {table.getHeaderGroups().map(headerGroup => (
               <tr key={headerGroup.id}>
-                {headerGroup.headers.map(header => (
+                {headerGroup.headers.map((header, index) => (
                   <th
                     key={header.id}
                     className={cn(
                       "px-2 py-3 text-left text-md font-medium text-neutral-500 uppercase tracking-wider min-w-[175px]",
-                      header.column.getCanSort() ? 'cursor-pointer select-none' : ''
+                      header.column.getCanSort() ? 'cursor-pointer select-none' : '',
+                      index < headerGroup.headers.length - 1 && 'border-r border-neutral-200'
                     )}
                   >
                     {flexRender(
@@ -223,8 +233,11 @@ const tableData: TableRow[] = useMemo(() => {
           <tbody className="bg-white divide-y divide-neutral-200">
             {table.getRowModel().rows.map(row => (
               <tr key={row.id}>
-                {row.getVisibleCells().map(cell => (
-                  <td key={cell.id} className="py-2">
+                {row.getVisibleCells().map((cell, index) => (
+                  <td key={cell.id}                     className={cn(
+                    "py-2",
+                    index < row.getVisibleCells().length - 1 && 'border-r border-neutral-200'
+                  )}>
                     {flexRender(
                         cell.column.columnDef.cell,
                         cell.getContext()

--- a/lib/storage-types.ts
+++ b/lib/storage-types.ts
@@ -6,7 +6,7 @@ import {
   FaHdd,
   FaWifi,
   FaExchangeAlt,
-  FaShieldAlt
+  FaShieldAlt,
 } from 'react-icons/fa';
 import { FaFile } from "react-icons/fa6";
 import { SlSpeedometer } from "react-icons/sl";
@@ -14,7 +14,8 @@ import { MdSdStorage } from "react-icons/md";
 import { AiOutlineCluster } from "react-icons/ai";
 import { SiDoi } from "react-icons/si";
 import { SiCanvas } from "react-icons/si";
-import { LuDatabaseBackup } from "react-icons/lu";
+import { MdOutlineFlipCameraIos } from "react-icons/md";
+import { LuDatabaseBackup } from "react-icons/lu"
 
 // --- Helper Mappings for Icons and Feature Value Colors ---
 export const featureIcons: Record<string, React.ElementType> = {
@@ -24,8 +25,8 @@ export const featureIcons: Record<string, React.ElementType> = {
   'sharing': FaShareSquare,
   'capacity': FaHdd,
   'doi_provided': SiDoi,
-  'data_protection_snapshots': LuDatabaseBackup,
-  'data_projection_replication': LuDatabaseBackup,
+  'data_protection_snapshots': MdOutlineFlipCameraIos,
+  'data_protection_replication': LuDatabaseBackup,
   'canvas_integration': SiCanvas,
   'brown_network_required': FaWifi,
   'access_from_oscar': AiOutlineCluster,


### PR DESCRIPTION
This PR turns the Services in the Storage Table header into next links that re-route to service info in main storage page. So clicking on Google Drive takes you to the Google Drive section of `/services/storage` and so on.

Also found a bug in some of the Feature icons and in the text for `Globus` and `Campus File Storage/Department File Services`. I changed the text to say "-" rather than "Undefined", but maybe we want to fill out the cell values in `/content/services/storage/storage-tool.yaml`?