### PR TITLE
Chore remove hero jpeg

### DIFF
--- a/app/content/services/stronghold.mdx
+++ b/app/content/services/stronghold.mdx
@@ -1,5 +1,4 @@
 <StyledHero 
-  image="/images/hero/hero.jpeg" 
   title="Stronghold" 
   description="Stronghold is a secure computing and storage environment that enables Brown researchers to analyze sensitive data while complying with regulatory or contractual requirements."
 />

--- a/app/services/classroom/page.tsx
+++ b/app/services/classroom/page.tsx
@@ -35,7 +35,6 @@ export default async function ClassroomSupport() {
       <div className="relative w-full flex flex-col">
         <div className="bg-blue-navbar">
           <Hero 
-            image={"/images/hero/hero.jpeg"}
             title="Classroom Support"
             description="CCV services to help faculty in the classroom. We can provide tutorial or give you access to cutting edge technology for teaching with code"
             titleClassName="font-bold text-6xl md:text-8xl"

--- a/app/services/consulting/page.tsx
+++ b/app/services/consulting/page.tsx
@@ -7,7 +7,6 @@ export default async function Consulting() {
       <div className="relative w-full flex flex-col">
         <div className="bg-blue-navbar">
           <Hero 
-            image={"/images/hero/hero.jpeg"}
             title="Consulting"
             description="Text tbd."
             titleClassName="font-bold text-6xl md:text-8xl"

--- a/app/services/oscar/page.tsx
+++ b/app/services/oscar/page.tsx
@@ -18,7 +18,6 @@ export default async function Oscar() {
       <div className="relative w-full flex flex-col">
         <div className="bg-blue-navbar">
           <Hero 
-            image={"/images/hero/hero.jpeg"}
             title={pageContentData.data.title}
             description={pageContentData.data.description}
             titleClassName="font-bold text-6xl md:text-8xl"

--- a/app/services/rates/page.tsx
+++ b/app/services/rates/page.tsx
@@ -28,7 +28,6 @@ export default async function Rates() {
       <div className="relative w-full flex flex-col">
         <div className="bg-blue-navbar">
           <Hero 
-            image={"/images/hero/hero.jpeg"}
             title="Rates"
             description="We provide services with limited resources at no cost to all members affiliated with Brown. For advanced computing that requires extra resources, we charge a monthly fee."
             titleClassName="font-bold text-6xl md:text-8xl"

--- a/app/services/storage/compare/page.tsx
+++ b/app/services/storage/compare/page.tsx
@@ -54,7 +54,6 @@ export default async function CompareStorageOptions() {
       <div className="relative w-full flex flex-col">
         <div className="bg-blue-navbar">
           <Hero 
-            image={"/images/hero-subroutes.jpeg"}
             title={pageContent.title}
             description={pageContent.description}
             titleClassName="font-bold text-6xl md:text-8xl"

--- a/app/services/storage/page.tsx
+++ b/app/services/storage/page.tsx
@@ -21,8 +21,7 @@ export default async function Storage() {
     <div className="w-full">
       <div className="relative w-full flex flex-col">
         <div className="bg-blue-navbar">
-          <Hero 
-            image={"/images/hero/hero.jpeg"}
+          <Hero  
             title="Storage and Transfer"
             description={pageContent?.description}
             titleClassName="font-bold text-6xl md:text-8xl"

--- a/app/services/user-support/page.tsx
+++ b/app/services/user-support/page.tsx
@@ -7,7 +7,6 @@ export default async function UserSupport() {
       <div className="relative w-full flex flex-col">
         <div className="bg-blue-navbar">
           <Hero 
-            image={"/images/hero/hero.jpeg"}
             title="User Support"
             description="Text tbd."
             titleClassName="font-bold text-6xl md:text-8xl"

--- a/app/services/virtual-machine-hosting/page.tsx
+++ b/app/services/virtual-machine-hosting/page.tsx
@@ -7,7 +7,6 @@ export default async function VirtualMachineHosting() {
       <div className="relative w-full flex flex-col">
         <div className="bg-blue-navbar">
           <Hero 
-            image={"/images/hero/hero.jpeg"}
             title="Virtual Machine Hosting"
             description="Text tbd."
             titleClassName="font-bold text-6xl md:text-8xl"

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from "react"
 
 interface HeroProps {
-  image: string
+  image?: string
   title?: string
   description?: string
   children?: ReactNode


### PR DESCRIPTION
This PR fixes the warning where hero.jpeg is passed to Hero on many pages. This is from before we changed the Hero from a stock image to a blue gradient.