### PR TITLE
fix: impact banner

### DIFF
--- a/components/ImpactBanner.tsx
+++ b/components/ImpactBanner.tsx
@@ -1,5 +1,6 @@
 import React, { type JSX } from "react"
 import { Card, CardContent } from "@/components/ui/Card"
+import { cardVariants } from "@/components/ui/variants"
 
 export const ImpactBanner = (): JSX.Element => {
   const impactMetrics = [
@@ -8,9 +9,9 @@ export const ImpactBanner = (): JSX.Element => {
     { count: "600+", label: "Collaborations" },
   ]
 
-  return (
-    <div className="content-wrapper h-auto bg-gray-100">
-      <Card className="w-full border-none shadow-none rounded-none bg-transparent">
+      return (
+      <div className="w-full">
+        <Card variant="content" className="bg-neutral-50 px-4">
         <CardContent className="max-w-[1440px] mx-auto max-h-[600px] flex items-center px-6 py-10">
           <div className="flex flex-wrap flex-col lg:flex-row justify-between flex-grow">
             <div className="flex flex-col items-center">

--- a/components/ui/Card.tsx
+++ b/components/ui/Card.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import { cn } from "@/lib/utils"
+import { cardVariants } from "./variants"
 
 interface CardHeaderProps extends React.HTMLAttributes<HTMLDivElement> {
   align?: "left" | "center" | "right"
@@ -11,12 +12,12 @@ interface CardDescriptionProps extends React.HTMLAttributes<HTMLDivElement> {
 
 const Card = React.forwardRef<
   HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
+  React.HTMLAttributes<HTMLDivElement> & { variant?: "default" | "people" | "content"; size?: "fit" | "contained" }
+>(({ className, variant = "default", size, ...props }, ref) => (
   <div
     ref={ref}
     className={cn(
-      "rounded-2xl border border-neutral-100 bg-gradient-to-br from-white to-neutral-50/30 text-card-foreground",
+      cardVariants({ variant, size }),
       className,
     )}
     {...props}

--- a/components/ui/variants.tsx
+++ b/components/ui/variants.tsx
@@ -124,7 +124,7 @@ export const cardVariants = cva(
     variants: {
       variant: {
         default:
-          "border border-neutral-300 bg-gradient-to-br from-white to-neutral-50/30 rounded-2xl",
+          "border border-neutral-300 bg-gradient-to-br from-neutral-50/30 to-white rounded-2xl",
         people: "border-none",
         content: "w-full border-none shadow-none rounded-none px-0",
       },


### PR DESCRIPTION
This PR fixes the impact banner style by removing the darker gray margins around the impact banner card and making the card w-full. This involved doing a small refactor of the Card component so default styles are applied from variants, rather than in the component itself. This will likely be refactored again in a bigger clean up, so I'm not too attached to this. Just a bandaid for our current card system.