### PR TITLE
fix: move attribution link outside of image div

### DIFF
--- a/components/FeaturedCarousel.tsx
+++ b/components/FeaturedCarousel.tsx
@@ -180,7 +180,7 @@ export const FeaturedCarousel: React.FC<FeaturedCarouselProps> = ({
 
             {/* Desktop Image Only */}
             <div className="hidden xl:block w-full max-w-[700px] lg:w-full h-full flex-col justify-center relative xl:ml-auto">
-              <div className="min-w-[700px]">
+              <div className="min-w-[700px] relative">
                 <Image
                   src={image}
                   alt={title}
@@ -189,19 +189,19 @@ export const FeaturedCarousel: React.FC<FeaturedCarouselProps> = ({
                   className="object-contain"
                   style={{ width: "700px", height: "500px" }}
                 />
-              </div>
 
-              {/* Attribution positioned at bottom-right of this div */}
-              {currentItem.attribution && (
-                <div className="absolute bottom-0 right-0 text-sm">
-                  <Markdown
-                    remarkPlugins={[remarkGfm]}
-                    rehypePlugins={[rehypeRaw]}
-                  >
-                    {currentItem.attribution}
-                  </Markdown>
-                </div>
-              )}
+                {/* Attribution if image requires it */}
+                {currentItem.attribution && (
+                  <div className="mt-2 text-right text-sm">
+                    <Markdown
+                      remarkPlugins={[remarkGfm]}
+                      rehypePlugins={[rehypeRaw]}
+                    >
+                      {currentItem.attribution}
+                    </Markdown>
+                  </div>
+                )}
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
This is a tiny PR that was affecting one attribution link in the classroom carousel.