### PR TITLE
refactor: moved badge color utilities from storage to Badge component

### DIFF
--- a/components/storage/utils.ts
+++ b/components/storage/utils.ts
@@ -51,89 +51,6 @@ export function sortFeatures<T extends { name: string } | string>(
 // Storage-specific badge utility functions
 
 /**
- * Determines whether text should be white or black based on the background color
- * Uses WCAG contrast guidelines for accessibility
- *
- * @param {string} backgroundColor - The background color (CSS class or hex)
- * @returns {string} - 'text-white' or 'text-black'
- */
-export const getTextColorForBackground = (backgroundColor: string): string => {
-  const colorMap: Record<string, string> = {
-    "bg-keppel-500": "text-black",
-    "bg-keppel-600": "text-white",
-    "bg-keppel-700": "text-white",
-    "bg-sunglow-400": "text-black",
-    "bg-sunglow-200": "text-black",
-    "bg-red-university": "text-white",
-    "bg-red-500": "text-white",
-    "bg-red-600": "text-white",
-    "bg-amber-600": "text-white",
-    "bg-amber-500": "text-white",
-    "bg-cyan-500": "text-white",
-    "bg-purple-900": "text-white",
-    "bg-purple-500": "text-white",
-    "bg-blue-500": "text-white",
-    "bg-blue-600": "text-white",
-    "bg-pink-500": "text-white",
-    "bg-neutral-800": "text-white",
-    "bg-neutral-900": "text-white",
-    "bg-neutral-200": "text-black",
-    "bg-neutral-300": "text-black",
-    "bg-neutral-400": "text-white",
-    "bg-neutral-500": "text-white",
-    "bg-neutral-600": "text-white",
-    "bg-neutral-700": "text-white",
-  }
-  return colorMap[backgroundColor] || "text-black"
-}
-
-/**
- * Maps feature values to badge background colors based on the storage-types color map
- */
-export const getBadgeBackgroundColor = (
-  value: string | boolean | number
-): string => {
-  const stringValue = String(value).toLowerCase()
-  const backgroundMap: Record<string, string> = {
-    high: "bg-red-university",
-    medium: "bg-amber-600",
-    low: "bg-keppel-600",
-    "0": "bg-keppel-600",
-    "1": "bg-sunglow-400",
-    "2": "bg-amber-600",
-    "3": "bg-red-university",
-    true: "bg-keppel-600",
-    false: "bg-red-university",
-    easy: "bg-keppel-600",
-    complex: "bg-red-university",
-    partial: "bg-sunglow-400",
-    "low cost": "bg-keppel-600",
-    "medium cost": "bg-sunglow-400",
-    "high cost": "bg-red-university",
-    hot: "bg-red-university",
-    warm: "bg-sunglow-400",
-    cold: "bg-cyan-500",
-    fastest: "bg-keppel-600",
-    faster: "bg-amber-600",
-    fast: "bg-sunglow-400",
-    slow: "bg-red-university",
-    small: "bg-cyan-500",
-    large: "bg-sunglow-400",
-    "4 gb": "bg-red-university",
-    "1 tb": "bg-amber-600",
-    "1 tb +": "bg-sunglow-400",
-    "2 tb +": "bg-sunglow-400",
-    "4 tb": "bg-sunglow-400",
-    "128 tb": "bg-sunglow-400",
-    "8 eb": "bg-keppel-600",
-    "9 eb": "bg-keppel-600",
-    unlimited: "bg-keppel-600",
-    default: "bg-neutral-200",
-  }
-  return backgroundMap[stringValue] || backgroundMap["default"]
-}
-
-/**
  * Maps feature names to appropriate badge colors for consistent styling
  */
 export const getBadgeColorForFeature = (featureName: string): string => {
@@ -159,19 +76,6 @@ export const getBadgeColorForFeature = (featureName: string): string => {
   }
   const normalizedName = featureName.toLowerCase().replace(/_/g, "")
   return featureMap[normalizedName] || featureMap["default"]
-}
-
-/**
- * Gets the complete badge styling for a feature value
- */
-export const getBadgeStyling = (value: string | boolean | number) => {
-  const backgroundColor = getBadgeBackgroundColor(value)
-  const textColor = getTextColorForBackground(backgroundColor)
-  return {
-    backgroundColor,
-    textColor,
-    className: `${backgroundColor} ${textColor}`,
-  }
 }
 
 // Storage-specific and semantic badge color variants for use in storage components

--- a/components/ui/Badge.tsx
+++ b/components/ui/Badge.tsx
@@ -1,6 +1,5 @@
 import React from "react"
 import { cn } from "@/lib/utils"
-import { getBadgeStyling } from "@/components/storage/utils"
 import { cva, VariantProps } from "class-variance-authority"
 
 // The badge system:
@@ -60,6 +59,102 @@ export const BadgeVariants = cva(
     },
   }
 )
+
+/**
+ * Determines whether text should be white or black based on the background color
+ * Uses WCAG contrast guidelines for accessibility
+ *
+ * @param {string} backgroundColor - The background color (CSS class or hex)
+ * @returns {string} - 'text-white' or 'text-black'
+ */
+export const getTextColorForBackground = (backgroundColor: string): string => {
+  const colorMap: Record<string, string> = {
+    "bg-keppel-500": "text-black",
+    "bg-keppel-600": "text-white",
+    "bg-keppel-700": "text-white",
+    "bg-sunglow-400": "text-black",
+    "bg-sunglow-200": "text-black",
+    "bg-red-university": "text-white",
+    "bg-red-500": "text-white",
+    "bg-red-600": "text-white",
+    "bg-amber-600": "text-white",
+    "bg-amber-500": "text-white",
+    "bg-cyan-500": "text-white",
+    "bg-purple-900": "text-white",
+    "bg-purple-500": "text-white",
+    "bg-blue-500": "text-white",
+    "bg-blue-600": "text-white",
+    "bg-pink-500": "text-white",
+    "bg-neutral-800": "text-white",
+    "bg-neutral-900": "text-white",
+    "bg-neutral-200": "text-black",
+    "bg-neutral-300": "text-black",
+    "bg-neutral-400": "text-white",
+    "bg-neutral-500": "text-white",
+    "bg-neutral-600": "text-white",
+    "bg-neutral-700": "text-white",
+  }
+  return colorMap[backgroundColor] || "text-black"
+}
+
+/**
+ * Maps feature values to badge background colors based on the storage-types color map
+ */
+export const getBadgeBackgroundColor = (
+  value: string | boolean | number
+): string => {
+  const stringValue = String(value).toLowerCase()
+  const backgroundMap: Record<string, string> = {
+    high: "bg-red-university",
+    medium: "bg-amber-600",
+    low: "bg-keppel-600",
+    "0": "bg-keppel-600",
+    "1": "bg-sunglow-400",
+    "2": "bg-amber-600",
+    "3": "bg-red-university",
+    true: "bg-keppel-600",
+    false: "bg-red-university",
+    easy: "bg-keppel-600",
+    complex: "bg-red-university",
+    partial: "bg-sunglow-400",
+    "low cost": "bg-keppel-600",
+    "medium cost": "bg-sunglow-400",
+    "high cost": "bg-red-university",
+    hot: "bg-red-university",
+    warm: "bg-sunglow-400",
+    cold: "bg-cyan-500",
+    fastest: "bg-keppel-600",
+    faster: "bg-amber-600",
+    fast: "bg-sunglow-400",
+    slow: "bg-red-university",
+    small: "bg-cyan-500",
+    large: "bg-sunglow-400",
+    "4 gb": "bg-red-university",
+    "1 tb": "bg-amber-600",
+    "1 tb +": "bg-sunglow-400",
+    "2 tb +": "bg-sunglow-400",
+    "4 tb": "bg-sunglow-400",
+    "128 tb": "bg-sunglow-400",
+    "8 eb": "bg-keppel-600",
+    "9 eb": "bg-keppel-600",
+    unlimited: "bg-keppel-600",
+    default: "bg-neutral-200",
+  }
+  return backgroundMap[stringValue] || backgroundMap["default"]
+}
+
+/**
+ * Gets the complete badge styling for a feature value
+ */
+export const getBadgeStyling = (value: string | boolean | number) => {
+  const backgroundColor = getBadgeBackgroundColor(value)
+  const textColor = getTextColorForBackground(backgroundColor)
+  return {
+    backgroundColor,
+    textColor,
+    className: `${backgroundColor} ${textColor}`,
+  }
+}
 
 type BadgeProps = React.HTMLAttributes<HTMLDivElement> &
   VariantProps<typeof BadgeVariants> & {


### PR DESCRIPTION
Moved badge utilities from storage/utils to Badge.


Closes #263 