### PR TITLE
Refactor buttonlink

### DIFF
--- a/components/button/ButtonLink.tsx
+++ b/components/button/ButtonLink.tsx
@@ -9,6 +9,7 @@ import { cn } from "@/lib/utils"
 type ButtonLinkProps = React.PropsWithChildren<{
   external?: boolean
   className?: string
+  isCalendarEvent?: boolean
 }> &
   Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, "href"> &
   Omit<LinkProps, "href"> & {
@@ -36,6 +37,7 @@ export const ButtonLink: React.FC<ExternalProps> = ({
   variant = "unstyled",
   children,
   className = "",
+  isCalendarEvent = false,
   ...props
 }) => {
   let resolvedIconPosition = iconPosition
@@ -43,10 +45,6 @@ export const ButtonLink: React.FC<ExternalProps> = ({
   if (!resolvedIconPosition && rightIcon) resolvedIconPosition = "right"
 
   const resolvedSize = iconOnly && !size ? "icon" : size
-
-  // Check if this is a calendar event (has specific calendar styling)
-  const isCalendarEvent =
-    className.includes("bg-sunglow-300") || className.includes("bg-sunglow-200")
 
   if (external) {
     return (

--- a/components/calendar/CalendarMonth.tsx
+++ b/components/calendar/CalendarMonth.tsx
@@ -124,6 +124,7 @@ const CalendarMonth: React.FC<CalendarProps> = ({
                   href={event.url}
                   external={true}
                   className="flex gap-1 text-blue-500"
+                  isCalendarEvent={true}
                 >
                   <p className="font-semibold hover:underline">{event.title}</p>
                   <ArrowTopRightOnSquareIcon
@@ -160,6 +161,7 @@ const CalendarMonth: React.FC<CalendarProps> = ({
               href={event.url}
               external={true}
               className="flex gap-1 text-blue-500"
+              isCalendarEvent={true}
             >
               <p className="font-semibold hover:underline">{event.title}</p>
               <ArrowTopRightOnSquareIcon

--- a/components/calendar/CalendarWeekly.tsx
+++ b/components/calendar/CalendarWeekly.tsx
@@ -144,6 +144,7 @@ const CalendarWeekly: React.FC<CalendarProps> = ({
             href={event.url}
             external={true}
             className={`${calColor} group absolute inset-1 flex flex-col overflow-y-auto rounded-lg p-2 text-xs leading-5 md:text-sm lg:text-md`}
+            isCalendarEvent={true}
           >
             <p className="font-semibold text-blue-500">{event.title}</p>
             <p className="weekly-datetime flex items-center py-2 text-keppel-700">

--- a/components/card/EventsCard.tsx
+++ b/components/card/EventsCard.tsx
@@ -2,6 +2,7 @@ import { StyledCard } from "@/components/card/StyledCard"
 import React from "react"
 import { DataProps } from "@/components/EventSection"
 import Icon from "@/components/ui/RenderIcon"
+import ButtonLink from "@/components/button/ButtonLink"
 
 export const EventsCard: React.FC<DataProps> = ({
   date_time,
@@ -27,14 +28,14 @@ export const EventsCard: React.FC<DataProps> = ({
           <Icon iconName="FaClock" />
           {date_time}
         </div>
-        <a
-          className="flex gap-2 text-xl font-bold leading-6 text-blue-500 hover:underline md:text-2xl"
+        <ButtonLink
           href={url}
-          target="_blank"
-          rel="noopener noreferrer"
+          external={true}
+          className="flex gap-2 text-xl font-bold leading-6 text-blue-500 hover:underline md:text-2xl"
+          isCalendarEvent={true}
         >
           View Event <Icon iconName="FaExternalLinkAlt" size={16} />
-        </a>
+        </ButtonLink>
         {description_long && <p>{descriptionLong}</p>}
       </div>
     </StyledCard>

--- a/components/card/EventsCard.tsx
+++ b/components/card/EventsCard.tsx
@@ -2,7 +2,6 @@ import { StyledCard } from "@/components/card/StyledCard"
 import React from "react"
 import { DataProps } from "@/components/EventSection"
 import Icon from "@/components/ui/RenderIcon"
-import ButtonLink from "@/components/button/ButtonLink"
 
 export const EventsCard: React.FC<DataProps> = ({
   date_time,
@@ -28,14 +27,14 @@ export const EventsCard: React.FC<DataProps> = ({
           <Icon iconName="FaClock" />
           {date_time}
         </div>
-        <ButtonLink
-          href={url}
-          external={true}
+        <a
           className="flex gap-2 text-xl font-bold leading-6 text-blue-500 hover:underline md:text-2xl"
-          isCalendarEvent={true}
+          href={url}
+          target="_blank"
+          rel="noopener noreferrer"
         >
           View Event <Icon iconName="FaExternalLinkAlt" size={16} />
-        </ButtonLink>
+        </a>
         {description_long && <p>{descriptionLong}</p>}
       </div>
     </StyledCard>


### PR DESCRIPTION
* Adds an `isCalendarEvent` prop to ButtonLink and removes the logic to determine if it is a calendar event based on styling 
* Updated ButtonLink calls on the Calendar, Weekly, and Event views where it matters 

This was done based on a recommendation from the copilot PR review on the CBC website.
