### PR TITLE
fix: attribution links for images in carousel

### DIFF
--- a/components/FeaturedCarousel.tsx
+++ b/components/FeaturedCarousel.tsx
@@ -4,6 +4,7 @@ import React, { useState } from "react"
 import { Badge } from "@/components/ui/Badge"
 import { getColorForTag } from "@/lib/utils"
 import { Button } from "@/components/button/Button"
+import { ButtonLink } from "@/components/button/ButtonLink"
 import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react"
 import Image from "next/image"
 import Icon from "@/components/ui/RenderIcon"
@@ -50,6 +51,7 @@ export const FeaturedCarousel: React.FC<FeaturedCarouselProps> = ({
   const currentItem = carouselData[idx]
   const { title, categories, description, image, organizations, buttons } =
     currentItem
+  const attribution = currentItem.attribution
 
   const prev = () => setIdx((i) => (i === 0 ? carouselData.length - 1 : i - 1))
   const next = () => setIdx((i) => (i === carouselData.length - 1 ? 0 : i + 1))
@@ -72,12 +74,10 @@ export const FeaturedCarousel: React.FC<FeaturedCarouselProps> = ({
           <div className="flex items-center justify-center gap-4">
             <Button
               variant="secondary_filled"
-              size="icon"
+              iconOnly={<ChevronLeftIcon className="h-6 w-6" strokeWidth={2.5} />}
               aria-label="previous project"
               onClick={prev}
-            >
-              <ChevronLeftIcon className="h-6 w-6" strokeWidth={2.5} />
-            </Button>
+            />
 
             {/* Pagination Dots */}
             <div className="flex gap-1">
@@ -94,12 +94,10 @@ export const FeaturedCarousel: React.FC<FeaturedCarouselProps> = ({
 
             <Button
               variant="secondary_filled"
-              size="icon"
+              iconOnly={<ChevronRightIcon className="h-6 w-6" strokeWidth={2.5} />}
               aria-label="next project"
               onClick={next}
-            >
-              <ChevronRightIcon className="h-6 w-6" strokeWidth={2.5} />
-            </Button>
+            />
           </div>
 
           <div className="mt-8 flex flex-col gap-8 lg:flex-row lg:items-start">
@@ -158,15 +156,16 @@ export const FeaturedCarousel: React.FC<FeaturedCarouselProps> = ({
               {buttons && buttons.length > 0 && (
                 <div className="flex flex-wrap gap-4">
                   {buttons.map((button, index) => (
-                    <Button
+                    <ButtonLink
                       key={index}
                       variant={button.variant}
                       size="md"
                       className="whitespace-nowrap"
-                      onClick={() => window.open(button.url, "_blank")}
+                      href={button.url}
+                      external={true}
                     >
                       {button.text}
-                    </Button>
+                    </ButtonLink>
                   ))}
                 </div>
               )}
@@ -184,20 +183,20 @@ export const FeaturedCarousel: React.FC<FeaturedCarouselProps> = ({
               />
 
               {/* Attribution if image requires it */}
-              {currentItem.attribution && currentItem.attribution.length > 0 && (
+              {attribution && attribution.length > 0 && (
                 <div className="mt-2 text-right">
                   <span className="sr-only">Image attribution: </span>
-                  {currentItem.attribution.map((attribution, index) => (
+                  {attribution.map((attributionItem, index) => (
                     <span key={index}>
                       <a 
-                        href={attribution.href} 
+                        href={attributionItem.href} 
                         target="_blank" 
                         rel="noopener noreferrer"
-                        aria-label={`${attribution.display_text} (opens in new tab)`}
+                        aria-label={`${attributionItem.display_text}`}
                       >
-                        {attribution.display_text}
+                        {attributionItem.display_text}
                       </a>
-                      {index < currentItem.attribution!.length - 1 && ", "}
+                      {index < attribution.length - 1 && ", "}
                     </span>
                   ))}
                 </div>

--- a/components/FeaturedCarousel.tsx
+++ b/components/FeaturedCarousel.tsx
@@ -192,7 +192,7 @@ export const FeaturedCarousel: React.FC<FeaturedCarouselProps> = ({
                         href={attributionItem.href} 
                         target="_blank" 
                         rel="noopener noreferrer"
-                        aria-label={attributionItem.display_text}
+                        aria-label={`Image attribution: ${attributionItem.display_text}`}
                       >
                         {attributionItem.display_text}
                       </a>

--- a/components/FeaturedCarousel.tsx
+++ b/components/FeaturedCarousel.tsx
@@ -192,7 +192,7 @@ export const FeaturedCarousel: React.FC<FeaturedCarouselProps> = ({
                         href={attributionItem.href} 
                         target="_blank" 
                         rel="noopener noreferrer"
-                        aria-label={`${attributionItem.display_text}`}
+                        aria-label={attributionItem.display_text}
                       >
                         {attributionItem.display_text}
                       </a>

--- a/components/FeaturedCarousel.tsx
+++ b/components/FeaturedCarousel.tsx
@@ -17,7 +17,10 @@ export interface FeaturedCarouselItem {
   categories: string[]
   description: string
   image: string
-  attribution?: string
+  attribution?: {
+    display_text: string
+    href: string
+  }[]
   organizations?: {
     name: string
     organization: string
@@ -181,14 +184,22 @@ export const FeaturedCarousel: React.FC<FeaturedCarouselProps> = ({
               />
 
               {/* Attribution if image requires it */}
-              {currentItem.attribution && (
+              {currentItem.attribution && currentItem.attribution.length > 0 && (
                 <div className="mt-2 text-right">
-                  <Markdown
-                    remarkPlugins={[remarkGfm]}
-                    rehypePlugins={[rehypeRaw]}
-                  >
-                    {currentItem.attribution}
-                  </Markdown>
+                  <span className="sr-only">Image attribution: </span>
+                  {currentItem.attribution.map((attribution, index) => (
+                    <span key={index}>
+                      <a 
+                        href={attribution.href} 
+                        target="_blank" 
+                        rel="noopener noreferrer"
+                        aria-label={`${attribution.display_text} (opens in new tab)`}
+                      >
+                        {attribution.display_text}
+                      </a>
+                      {index < currentItem.attribution!.length - 1 && ", "}
+                    </span>
+                  ))}
                 </div>
               )}
             </div>

--- a/components/FeaturedCarousel.tsx
+++ b/components/FeaturedCarousel.tsx
@@ -184,15 +184,14 @@ export const FeaturedCarousel: React.FC<FeaturedCarouselProps> = ({
 
               {/* Attribution if image requires it */}
               {attribution && attribution.length > 0 && (
-                <div className="mt-2 text-right">
-                  <span className="sr-only">Image attribution: </span>
+                <div className="mt-2 text-right" aria-label="Image attribution">
                   {attribution.map((attributionItem, index) => (
                     <span key={index}>
                       <a 
                         href={attributionItem.href} 
                         target="_blank" 
                         rel="noopener noreferrer"
-                        aria-label={`Image attribution: ${attributionItem.display_text}`}
+                        aria-label={attributionItem.display_text}
                       >
                         {attributionItem.display_text}
                       </a>

--- a/content/services/classroom-carousel.yaml
+++ b/content/services/classroom-carousel.yaml
@@ -7,7 +7,7 @@ carousel:
       - display_text: open{code}.md
         href: 'https://opencode.md/en/news/why-use-linux/'
       - display_text: "Larry Ewing"
-        href: 'lewing@isc.tamu.edu'
+        href: 'mailto:lewing@isc.tamu.edu'
       - display_text: "The GIMP"
         href: 'https://web.archive.org/web/20190927022731/https://isc.tamu.edu/~lewing/gimp/'
     buttons:

--- a/content/services/classroom-carousel.yaml
+++ b/content/services/classroom-carousel.yaml
@@ -3,7 +3,13 @@ carousel:
     categories: ["Linux"]
     description: "A practical introduction to the Linux operating system and shell scripting in Bash. Topics covered include: basic Linux commands for maneuvering within the file system and manipulating files, working with environment variables and paths, and basic shell scripting in Bash (variables, loops, pipes, etc.)."
     image: "/images/services/classroom/featured-carousel/linux.jpg"
-    attribution: "Photo by <a href='https://opencode.md/en/news/why-use-linux/'>open{code}.md</a>. Tux image created by <a href='lewing@isc.tamu.edu'>Larry Ewing</a> and <a href='https://web.archive.org/web/20190927022731/https://isc.tamu.edu/~lewing/gimp/'>The GIMP</a>."
+    attribution: 
+      - display_text: open{code}.md
+        href: 'https://opencode.md/en/news/why-use-linux/'
+      - display_text: "Larry Ewing"
+        href: 'lewing@isc.tamu.edu'
+      - display_text: "The GIMP"
+        href: 'https://web.archive.org/web/20190927022731/https://isc.tamu.edu/~lewing/gimp/'
     buttons:
       - text: "View Recorded Session"
         url: "https://brown.hosted.panopto.com/Panopto/Pages/Viewer.aspx?id=71a75ae2-d067-4679-a7b7-b2f001520f47"
@@ -28,7 +34,9 @@ carousel:
     categories: ["Statistics"]
     description: "An introduction to MATLAB, a programming language for numerical computation and visualization. Topics covered include: basic MATLAB commands, working with arrays and matrices, plotting data, and using functions."
     image: "/images/services/classroom/featured-carousel/matlab.jpeg"
-    attribution: "Photo by <a href='https://creativecommons.org/licenses/by-sa/4.0/'>Jschlosser</a>."
+    attribution: 
+      - display_text: "Jschlosser"
+        href: 'https://creativecommons.org/licenses/by-sa/4.0/'
     buttons:
       - text: "View Recorded Session"
         url: "https://brown.hosted.panopto.com/Panopto/Pages/Viewer.aspx?id=88fa9718-0367-4f27-95ae-b2fa010dddd6"
@@ -37,7 +45,9 @@ carousel:
     categories: ["Statistics"]
     description: "An introduction to R, a programming language for statistical computing and graphics. Topics covered include: basic R commands, working with data frames, plotting data, and using functions."
     image: "/images/services/classroom/featured-carousel/r.png"
-    attribution: "Photo by <a href='https://creativecommons.org/licenses/by-sa/4.0/'>cdhowe</a>."
+    attribution: 
+      - display_text: "cdhowe"
+        href: 'https://creativecommons.org/licenses/by-sa/4.0/'
     buttons:
       - text: "View Notebook"
         url: "https://github.com/compbiocore/ccv_bootcamp_R"


### PR DESCRIPTION
makes attribution links an array of objects, open in new tab, and adds `sr-only` and `aria-labels`