### PR TITLE
fix: styledtab erroneously shows up on mobile view

### DIFF
--- a/components/EventSection.tsx
+++ b/components/EventSection.tsx
@@ -54,7 +54,12 @@ export function EventSection({
         </ButtonLink>
       </div>
 
-      {/* Right: Toggle and Views */}
+      {/* Mobile: Show only upcoming events */}
+      <div className="md:hidden">
+        <UpcomingEvents events={dataFuture} />
+      </div>
+
+      {/* Desktop: Toggle and Views */}
       <div className="hidden md:flex">
         <StyledTabs
           variant="neutral"

--- a/components/EventSection.tsx
+++ b/components/EventSection.tsx
@@ -55,7 +55,7 @@ export function EventSection({
       </div>
 
       {/* Right: Toggle and Views */}
-      <div className="hidden md:block">
+      <div className="hidden md:flex">
         <StyledTabs
           variant="neutral"
           tabs={[

--- a/components/EventSection.tsx
+++ b/components/EventSection.tsx
@@ -55,10 +55,10 @@ export function EventSection({
       </div>
 
       {/* Right: Toggle and Views */}
-      <StyledTabs
-        className="hidden md:flex"
-        variant="neutral"
-        tabs={[
+      <div className="hidden md:block">
+        <StyledTabs
+          variant="neutral"
+          tabs={[
           {
             value: "upcoming",
             label: "Upcoming",
@@ -87,7 +87,8 @@ export function EventSection({
             ),
           },
         ]}
-      />
+        />
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
moves `hidden md:block` outside of styledtab into an outer div