### PR TITLE
fix: navbar highlight on submenu open

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -247,7 +247,7 @@ export const Navbar: React.FC = () => {
           <NavigationMenu.List className="flex h-full items-center">
             {routes.map((section) => (
               <NavigationMenu.Item key={section.name}>
-                <NavigationMenu.Trigger className="group inline-flex h-9 items-center justify-center gap-2 px-3 text-xl font-semibold text-white transition-colors hover:text-sunglow-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-sunglow-400 disabled:pointer-events-none disabled:opacity-50 xl:px-6">
+                <NavigationMenu.Trigger className="group inline-flex h-9 items-center justify-center gap-2 px-3 text-xl font-semibold text-white transition-colors hover:text-sunglow-400 data-[state=open]:text-sunglow-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-sunglow-400 disabled:pointer-events-none disabled:opacity-50 xl:px-6">
                   {section.name}
                   <FaChevronDown
                     className="relative top-[1px] h-3 w-3 transition duration-300 group-data-[state=open]:rotate-180 xl:ml-1"


### PR DESCRIPTION
This is a tiny PR that fixes the issue where the navbar heading doesn't stay highlighted sunglow whenever the submenu is open.