### PR TITLE
fix: correct JupyterLab reference to JupyterHub in classroom

### DIFF
--- a/content/services/classroom.mdx
+++ b/content/services/classroom.mdx
@@ -32,7 +32,7 @@ Google Colab comes bundled with most Python-specific software libraries, and it 
 
 <Button href="https://colab.google">Learn More</Button>
 
-### Brown JupyterLab
+### Brown JupyterHub
 
 For more advanced needs, Brown's JupyterHub may be a good fit for your needs. If you are an instructor, CCV can provide access to JupyterHub for your class or workshop, and Digital Learning and Design (DLD) can assist with integrating computational assignments into curricula. The implementation is supported by Brown OIT; please follow the link below to request an instance for your class. OIT staff will respond to your request to begin the setup process. We ask that requests for JupyterHub be made at least two months in advance of expected course deployment.
 


### PR DESCRIPTION
closes #347 