### PR TITLE
chore: standardize documentation buttons

### DIFF
--- a/app/services/oscar/page.tsx
+++ b/app/services/oscar/page.tsx
@@ -23,7 +23,7 @@ export default async function Oscar() {
           external={true}
           href="https://docs.ccv.brown.edu/oscar"
         >
-          Read the Docs
+          Documentation
         </ButtonLink>
       </Hero>
       <OscarContent />


### PR DESCRIPTION
This tiny PR changes the Oscar hero button link to the Oscar Documentation page to be consistent with the button link text on the Stronghold page