### PR TITLE
feat: pull zoom link from events api

### DIFF
--- a/components/calendar/CalendarMonth.tsx
+++ b/components/calendar/CalendarMonth.tsx
@@ -103,7 +103,8 @@ const CalendarMonth: React.FC<CalendarProps> = ({
       (event) => event.date_time !== undefined
     )
 
-    const formattedCalEvents = validDayEvents.map((event: DataProps) => {
+    const formattedCalEvents = validDayEvents.map((event: DataProps & { online_url?: string | null }) => {
+      const eventUrl = event.online_url != null ? event.online_url : event.url
       return (
         <li key={self.crypto.randomUUID()}>
           <Popover>
@@ -120,7 +121,7 @@ const CalendarMonth: React.FC<CalendarProps> = ({
             <PopoverContent className="bg-neutral-50">
               <p className="pb-2 font-semibold">{event.date}</p>
               <ButtonLink
-                href={event.url}
+                href={eventUrl}
                 external={true}
                 className="flex gap-1 text-blue-500"
                 isCalendarEvent={true}
@@ -148,7 +149,8 @@ const CalendarMonth: React.FC<CalendarProps> = ({
       )
     })
 
-    const formattedContainerEvents = dayEvents.map((event, i) => {
+    const formattedContainerEvents = dayEvents.map((event: DataProps & { online_url?: string | null }, i) => {
+      const eventUrl = event.online_url != null ? event.online_url : event.url
       return (
         <li
           key={self.crypto.randomUUID()}
@@ -156,7 +158,7 @@ const CalendarMonth: React.FC<CalendarProps> = ({
         >
           <div className="flex-auto">
             <ButtonLink
-              href={event.url}
+              href={eventUrl}
               external={true}
               className="flex gap-1 text-blue-500"
               isCalendarEvent={true}
@@ -320,6 +322,8 @@ const CalendarMonth: React.FC<CalendarProps> = ({
       </div>
     )
   }
+
+  console.log(events)
 
   return (
     <div className="not-prose lg:flex lg:h-full lg:flex-col">

--- a/components/calendar/CalendarWeekly.tsx
+++ b/components/calendar/CalendarWeekly.tsx
@@ -118,7 +118,7 @@ const CalendarWeekly: React.FC<CalendarProps> = ({
         isBefore(event.date_utc, addDays(startDate, 7))
     )
 
-    const formattedWeekEvents = weekEvents.map((event, i) => {
+    const formattedWeekEvents = weekEvents.map((event: any, i) => {
       thisDate = addDays(startDate, i)
       const lengthOfTime = differenceInHours(event.date2_utc, event.date_utc)
       const dayOfWeek = getDay(addDays(event.date_iso, 1))
@@ -141,7 +141,7 @@ const CalendarWeekly: React.FC<CalendarProps> = ({
           }}
         >
           <ButtonLink
-            href={event.url}
+            href={event.online_url != null ? event.online_url : event.url}
             external={true}
             className={`${calColor} group absolute inset-1 flex flex-col gap-2 overflow-y-auto rounded-lg p-2 text-xs leading-tight lg:text-base`}
             isCalendarEvent={true}


### PR DESCRIPTION
This PR changes the weekly/monthly calendar event links to use "online_url" instead of "url" if it is not null. This allows the zoom link to be pulled directly from the events API in case it changes in the future and a hardcoded link would break.