### PR TITLE
feat: dscov query

### DIFF
--- a/app/queries.js
+++ b/app/queries.js
@@ -22,6 +22,18 @@ async function getDscovData(time) {
   return filteredData
 }
 
+function compareDate2Utc(a, b) {
+  const dateA = new Date(a.date2_utc)
+  const dateB = new Date(b.date2_utc)
+  const validA = !isNaN(dateA.getTime())
+  const validB = !isNaN(dateB.getTime())
+
+  if (!validA && !validB) return 0
+  if (!validA) return 1 // a is invalid, push to end
+  if (!validB) return -1 // b is invalid, push to end
+  return dateA - dateB
+}
+
 export async function getEventData(time) {
   const [ccvData, dscovData] = await Promise.all([
     getCCVData(time),
@@ -29,6 +41,7 @@ export async function getEventData(time) {
   ])
 
   const combinedData = [...ccvData, ...dscovData]
+  combinedData.sort(compareDate2Utc)
 
   return combinedData
 }

--- a/app/queries.js
+++ b/app/queries.js
@@ -1,5 +1,3 @@
-import { get } from "http"
-
 async function getCCVData(time) {
   const response = await fetch(
     `https://events.brown.edu/live/json/events/description_long/true/group/Center%20for%20Computation%20and%20Visualization%20%28CCV%29/start_date/${time}/`

--- a/app/queries.js
+++ b/app/queries.js
@@ -1,7 +1,36 @@
-export async function getEventData(time) {
+import { get } from "http"
+
+async function getCCVData(time) {
   const response = await fetch(
     `https://events.brown.edu/live/json/events/description_long/true/group/Center%20for%20Computation%20and%20Visualization%20%28CCV%29/start_date/${time}/`
   )
   const data = await response.json()
   return data
+}
+
+async function getDscovData(time) {
+  const description_long = true
+  const group = "Data%20Science%20Institute"
+  const response = await fetch(
+    `https://events.brown.edu/live/json/events/description_long/${description_long}/group/${group}/start_date/${time}/`
+  )
+  const data = await response.json()
+
+  // Filter for only DSCOV events
+  const filteredData = data.filter((event) =>
+    event.title.toLowerCase().includes("dscov")
+  )
+
+  return filteredData
+}
+
+export async function getEventData(time) {
+  const [ccvData, dscovData] = await Promise.all([
+    getCCVData(time),
+    getDscovData(time),
+  ])
+
+  const combinedData = [...ccvData, ...dscovData]
+
+  return combinedData
 }

--- a/components/calendar/CalendarWeekly.tsx
+++ b/components/calendar/CalendarWeekly.tsx
@@ -120,7 +120,10 @@ const CalendarWeekly: React.FC<CalendarProps> = ({
 
     const formattedWeekEvents = weekEvents.map((event, i) => {
       thisDate = addDays(startDate, i)
-      const lengthOfTime = differenceInHours(event.date2_utc, event.date_utc)
+      const lengthOfTime =
+        event.date2_utc && event.date_utc
+          ? differenceInHours(event.date2_utc, event.date_utc)
+          : 1
       const dayOfWeek = getDay(addDays(event.date_iso, 1))
       const yearEvent = getYear(event.date_utc)
       const monthEvent = getMonth(event.date_utc)

--- a/components/card/EventsCard.tsx
+++ b/components/card/EventsCard.tsx
@@ -33,7 +33,9 @@ export const EventsCard: React.FC<DataProps> = ({
         >
           View Event <Icon iconName="FaExternalLinkAlt" size={16} />
         </a>
-        {description_long && <p>{descriptionLong}</p>}
+        {description_long && (
+          <p className="line-clamp-[8]"> {descriptionLong} </p>
+        )}
       </div>
     </StyledCard>
   )


### PR DESCRIPTION
Added DSCOV to events calendar. End times aren't encoded in the events so I had to write in a fix to make them 1 hour if the value is null.

Do we still want to move the query script to the client component now that's it's a bit more complicated? This is mentioned #455. 