### PR TITLE
fix: image warning

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -8,6 +8,10 @@ const nextConfig = {
   basePath: "",
   pageExtensions: ["js", "jsx", "md", "mdx", "ts", "tsx"],
   output: "standalone",
+  images: {
+    qualities: [75, 90, 100],
+    formats: ['image/webp', 'image/avif', 'image/jpeg'],
+  },
 }
 
 const withMDX = createMDX({

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -10,7 +10,7 @@ const nextConfig = {
   output: "standalone",
   images: {
     qualities: [75, 90, 100],
-    formats: ["image/webp", "image/avif", "image/jpeg"],
+    formats: ["image/webp", "image/avif"],
   },
 }
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -10,7 +10,7 @@ const nextConfig = {
   output: "standalone",
   images: {
     qualities: [75, 90, 100],
-    formats: ['image/webp', 'image/avif', 'image/jpeg'],
+    formats: ["image/webp", "image/avif", "image/jpeg"],
   },
 }
 


### PR DESCRIPTION
>Image with src "/images/hero/ccv-original.webp" is using quality "90" which is not configured in images.qualities. This config will be required starting in Next.js 16.
>Read more: https://nextjs.org/docs/messages/next-image-unconfigured-qualities