### PR TITLE
refactor: remove invalid class

### DIFF
--- a/components/SectionHeader.tsx
+++ b/components/SectionHeader.tsx
@@ -24,7 +24,7 @@ export const SectionHeader: React.FC<SectionHeaderProps> = ({
   return (
     <div
       className={cn(
-        `not-prose flex flex-col ${align === "center" ? "items-center" : "max-w-1/2 items-center lg:items-start"}`,
+        `not-prose flex flex-col ${align === "center" ? "items-center" : "items-center lg:items-start"}`,
         className
       )}
     >


### PR DESCRIPTION
`max-w-1/2` isn't a valid tailwind class, as such we can just remove it