### PR TITLE
fix: content section passes props

### DIFF
--- a/app/about/careers/page.tsx
+++ b/app/about/careers/page.tsx
@@ -28,7 +28,7 @@ export default async function Careers() {
           Contact Us
         </ButtonLink>
       </Hero>
-      <ContentSection className="bg-neutral-50">
+      <ContentSection className="bg-neutral-50" id="opportunities">
         <ContentHeader>
           <ContentTitle title="Opportunities" />
         </ContentHeader>

--- a/app/services/classroom/page.tsx
+++ b/app/services/classroom/page.tsx
@@ -17,7 +17,7 @@ export default async function ClassroomSupport() {
   return (
     <>
       <Hero title={metadata.title} description={metadata.description} />
-      <ContentSection className="px-none bg-neutral-50">
+      <ContentSection className="px-none bg-neutral-50" id="in-class-tutorials">
         <ContentHeader>
           <ContentTitle title="In-Class Tutorials" />
         </ContentHeader>

--- a/content/about/about-us.mdx
+++ b/content/about/about-us.mdx
@@ -4,7 +4,7 @@ image: "/images/hero/about-kayaks.webp"
 description: The Center for Computation and Visualization provides high-performance computing and visualization services to the Brown community and also collaborates with researchers on projects across a vast range of disciplines.
 ---
 
-<ContentSection title="Office of Information Technology">
+<ContentSection title="Office of Information Technology" id="oit">
   The Center for Computation and Visualization (CCV) is a center within the
   University's central IT organization, which is the Office of Information
   Technology (OIT). In addition to building and maintaining the University's
@@ -14,7 +14,7 @@ description: The Center for Computation and Visualization provides high-performa
   CCV plays in OIT.
 </ContentSection>
 
-<ContentSection title="Our Mission">
+<ContentSection title="Our Mission" id="our-mission">
   We envision an environment where computational best practices, innovative
   solutions, and expert knowledge combine to build advanced tools for research
   and to enable new discoveries. Our mission is to provide the scientific and
@@ -29,7 +29,7 @@ description: The Center for Computation and Visualization provides high-performa
   Science, etc.), so we can closely calibrate a person with a project.
 </ContentSection>
 
-<ContentSection title="Our Team">
+<ContentSection title="Our Team" id="our-team">
   <PeopleSection peopleContentPath="content/about/people.yaml" />
 </ContentSection>
 

--- a/content/about/careers.mdx
+++ b/content/about/careers.mdx
@@ -4,7 +4,7 @@ image: "/images/hero/about-kayaks.webp"
 description: Join our team of scientists, engineers, and technologists working to advance scientific discovery
 ---
 
-<ContentSection title="Diversity Statement">
+<ContentSection title="Diversity Statement" id="diversity-statement">
 CCV embraces a community enriched and enhanced by diverse dimensions, including race, ethnicity and national origins,
 disability status, gender and gender identity, sexuality, class and religion. We believe diversity brings innovation and
 progress. We are especially committed to increasing the representation of those populations that have been historically

--- a/content/about/grant-and-publication-materials.mdx
+++ b/content/about/grant-and-publication-materials.mdx
@@ -3,7 +3,7 @@ title: Grant and Publication Materials
 description: Materials to strengthen your grant proposals and how to cite CCV in your publications
 ---
 
-<ContentSection title="Grant Proposal Materials for CCV Collaborators">
+<ContentSection title="Grant Proposal Materials for CCV Collaborators" id="grant-proposal-materials">
   As you are preparing for a grant proposal that uses CCV resources or services, we can help provide strategic support 
   materials. 
   
@@ -35,7 +35,7 @@ description: Materials to strengthen your grant proposals and how to cite CCV in
   </Button>
 </ContentSection>
 
-<ContentSection title="Acknowledgment Statement">
+<ContentSection title="Acknowledgment Statement" id="acknowledgement-statement">
   Your acknowledgment helps CCV report on our impact at Brown. Clear acknowledgments help us track the impact of our services, which in turn supports continued support for our computational resources and staff.
 
   If you publish research that benefited from the use of CCV services or resources, we would greatly appreciate an acknowledgment that states:

--- a/content/about/help.mdx
+++ b/content/about/help.mdx
@@ -4,7 +4,7 @@ image: "/images/hero/about-kayaks.webp"
 description:  We offer a variety of support options designed to fit your needs. Choose the method that works best for you.
 ---
 
-<ContentSection title="Documentation">
+<ContentSection title="Documentation" id="documentation">
   Check out our <a href="https://docs.ccv.brown.edu/documentation/" target="_blank" rel="noopener noreferrer">documentation</a> 
   to find information and answers to common questions about using our systems.
 

--- a/content/ai/ai-oscar.mdx
+++ b/content/ai/ai-oscar.mdx
@@ -4,7 +4,7 @@ description: |
   Access to large language models and AI tools through Brown's high-performance computing cluster.
 ---
 
-<ContentSection title="GPUs on Oscar">
+<ContentSection title="GPUs on Oscar" id="gpus-on-oscar">
 
 Building modern deep learning models requires specialized hardware called graphics processing units (GPUs). Originally designed 
 for graphics rendering in computer games, GPUs' massively parallel architecture make them exceptionally well suited to the 
@@ -22,7 +22,7 @@ Oscar, from Titan RTX (24 GB VRAM) to B200 (180 GB VRAM).
 
 </ContentSection>
 
-<ContentSection title="Ollama">
+<ContentSection title="Ollama" id="ollama">
 
 Ollama is the easiest way to run large language models directly on Brown’s Oscar high‑performance computing cluster.
 Available as a preinstalled module, Ollama uses a simple client–server approach: you start a server on your allocated

--- a/content/ai/ai-tools.mdx
+++ b/content/ai/ai-tools.mdx
@@ -4,7 +4,7 @@ description: |
   Access to large language models and AI tools through CCV's computing infrastructure.
 ---
 
-<ContentSection title="About ChatCCV Tools">
+<ContentSection title="About ChatCCV Tools" id="chatccv">
 CCV provides access to cutting-edge AI tools and large language models through our high-performance computing
 infrastructure. Whether you need to run LLMs for research, explore AI capabilities, or integrate AI into your
 computational workflows, we have the resources and expertise to support your needs.
@@ -28,7 +28,7 @@ computational workflows, we have the resources and expertise to support your nee
   </CardGroup>
 </ContentSection>
 
-<ContentSection title="Experimental Tools">
+<ContentSection title="Experimental Tools" id="experimental tools">
   CCV is currently developing several proof-of-concept AI tools. Ask Oscar and LibreChat are available for experimental use, though they remain in active development and may undergo changes or discontinuation. Please note that documentation may be outdated or incomplete during this development phase.
 
     * Ask Oscar is an AI assistant that specializes in answering questions about Oscar, Brown University's HPC cluster. It has access to Oscar's documentation to help you find the information you need.

--- a/content/ai/ai-tools.mdx
+++ b/content/ai/ai-tools.mdx
@@ -28,7 +28,7 @@ computational workflows, we have the resources and expertise to support your nee
   </CardGroup>
 </ContentSection>
 
-<ContentSection title="Experimental Tools" id="experimental tools">
+<ContentSection title="Experimental Tools" id="experimental-tools">
   CCV is currently developing several proof-of-concept AI tools. Ask Oscar and LibreChat are available for experimental use, though they remain in active development and may undergo changes or discontinuation. Please note that documentation may be outdated or incomplete during this development phase.
 
     * Ask Oscar is an AI assistant that specializes in answering questions about Oscar, Brown University's HPC cluster. It has access to Oscar's documentation to help you find the information you need.

--- a/content/mdx-editing-guide.mdx
+++ b/content/mdx-editing-guide.mdx
@@ -4,7 +4,7 @@ description: |
   A guide for getting started using MDX files to create and edit content in the CCV website.
 ---
 
-<ContentSection title="What is MDX?">
+<ContentSection title="What is MDX?" id="what-is-mdx">
   MDX files combine regular text and Markdown formatting with React components and custom components to create a feature-rich, flexible, and easy-to-use content editing experience.
 
   The content of the MDX Editing Guide that you are _currently reading_ is rendered from an MDX file called `mdx-editing-guide.mdx`, which you can find in the `/content` folder of the CCV website codebase. It's extremely meta.
@@ -16,7 +16,7 @@ description: |
   </Button>
 </ContentSection>
 
-<ContentSection title="Available Components">
+<ContentSection title="Available Components" id="available-components">
   All available components are in the `/components` folder. To make them accessible in `.mdx` files, add them to `/mdx-components.tsx`. Import the component(s) at the top of the file and add it to the Global MDX Components section at the bottom. To request a new custom component, please add an issue to the CCV website github repository.
 
   <Button href="https://github.com/brown-ccv/ccv-website/issues">
@@ -33,7 +33,7 @@ description: |
   2. **Test your changes** - Run `npm run dev` to see your changes
 </ContentSection>
 
-<ContentSection title="Example MDX File">
+<ContentSection title="Example MDX File" id="example-mdx-file">
   ### This is an example of an MDX content file containing custom components and markdown formatting.
 
   ```tsx
@@ -69,7 +69,7 @@ description: |
   ### This is how the above example renders:
 </ContentSection>
 
-<ContentSection title="Welcome to the Wonderful World of MDX">
+<ContentSection title="Welcome to the Wonderful World of MDX" id="welcome">
   The `<ContentSection>` component is used to create a header for the page and apply styling to that page's section. It is a custom component that is defined in `/components/SectionHeader.tsx` and imported in `/mdx-components.tsx`. Every section of your page should be wrapped in a `<ContentSection>` component.
 
   Insert a button that links to a markdown cheat sheet and the `@next/mdx` documentation using the `<Button/>` component. It uses the same styling as the buttons that are used throughout this website. The `<ButtonGroup/>` component is used to group buttons together.

--- a/content/services/classroom.mdx
+++ b/content/services/classroom.mdx
@@ -4,7 +4,7 @@ description: |
   We support faculty in the classroom, providing tutorials or granting access to cutting edge technology for teaching with code.
 ---
 
-<ContentSection title="Student Accounts">
+<ContentSection title="Student Accounts" id="student-accounts">
 
 CCV provides access to HPC resources for classes, workshops, demonstrations, and other instructional uses. We do ask that you follow these guidelines to help us better support your class.
 
@@ -22,7 +22,7 @@ CCV provides access to HPC resources for classes, workshops, demonstrations, and
 </ButtonGroup>
 </ContentSection>
 
-<ContentSection title="Computational Notebooks">
+<ContentSection title="Computational Notebooks" id="computational-notebooks">
 
 Computational Notebooks provide a convenient, cloud-hosted way to serve Jupyter Notebooks for multiple users. Notebooks are launched within a pre-configured computing environment so that users do not need to install any software packages. This set-up free environment is ideal for courses and workshops where instructors intend for students to begin coding with minimal obstacles. Jupyter's flexibility allows instructors to pick the preferred language for a particular context, including Python, Julia, R and many more.
 
@@ -46,7 +46,7 @@ For more advanced needs, Brown's JupyterHub may be a good fit for your needs. If
 </ButtonGroup>
 </ContentSection>
 
-<ContentSection title="Contact Us">
+<ContentSection title="Contact Us" id="contact-us">
 
 Need help choosing the right computational tools for your classroom? CCV can help! We offer consultations to determine the best resources for your instructional needs.
 

--- a/content/services/department-support.mdx
+++ b/content/services/department-support.mdx
@@ -4,7 +4,7 @@ description: |
   We provide specialized support for specific Brown departments.
 ---
 
-<ContentSection title="Collaboration Across Brown">
+<ContentSection title="Collaboration Across Brown" id="collaboration-across-brown">
 Some academic departments and centers with high demand for computational resources have invested in specialized support 
 from CCV. Our dedicated team of system engineers provides personalized service and advanced administration and 
 troubleshooting for Linux and Windows systems, web-based services, research data management, database support, and more. 
@@ -23,7 +23,7 @@ We currently provide dedicated support to the following departments:
 
 </ContentSection>
 
-<ContentSection title="Contact Us">
+<ContentSection title="Contact Us" id="contact-us">
 
 <TwoColumns items={[
 "**If you are affiliated with one of the departments listed above:** \n \n Your department has a dedicated CCV representatives to assist with your specialized needs. Please open a support ticket and specify your department to ensure your request is routed correctly.",

--- a/content/services/oscar.mdx
+++ b/content/services/oscar.mdx
@@ -4,7 +4,7 @@ description: |
   Brown University's high performance computing cluster for both research and classes.
 ---
 
-<ContentSection title="Why Use High-Performance Computing?">
+<ContentSection title="Why Use High-Performance Computing?" id="hpc">
 High-Performance Computing (HPC), or supercomputing, is a powerful shared resource that can dramatically accelerate and
 expand the scope of your research. Unlike a personal computer with fixed capabilities, an HPC system provides a
 customizable and scalable pool of computing resources — processors, memory, and storage — that you can tailor to the
@@ -19,7 +19,7 @@ interconnect and file system.
 </Button>
 </ContentSection>
 
-<ContentSection title="Key Benefits for Researchers">
+<ContentSection title="Key Benefits for Researchers" id="key-benefits">
 <CardGroup>
   <StyledCard size="lg" iconName="" title="Solve Problems Faster">
     Oscar resources can reduce a calculation that would take months on a personal computer to just hours or minutes.
@@ -53,7 +53,7 @@ interconnect and file system.
 </CardGroup>
 </ContentSection>
 
-<ContentSection title="Is Oscar Right for You?">
+<ContentSection title="Is Oscar Right for You?" id="is-oscar-right-for-you">
 You don't need to be an expert in computing to use these resources. Consider if any of the following apply to your work:
 
 - Does your research involve large datasets?
@@ -76,7 +76,7 @@ CCV is here to help you get started and understand how these powerful tools can 
 
 </ContentSection>
 
-<ContentSection title="Contact Us">
+<ContentSection title="Contact Us" id="contact-us">
 
 Need help getting started with high-performance computing or determining if Oscar is right for your research? CCV can help! We offer consultations to assess your computational needs and provide guidance on how to leverage Oscar's powerful resources for your specific research projects.
 

--- a/content/services/project-consulting.mdx
+++ b/content/services/project-consulting.mdx
@@ -6,7 +6,7 @@ links:
     target: "/about/help#contact-us"
 ---
 
-<ContentSection title="Why Work with CCV?">
+<ContentSection title="Why Work with CCV?" id="why-ccv">
   Our team at the Center for Computation and Visualization (CCV) is composed of skilled data scientists, research software engineers, and system administrators. We believe in forming meaningful partnerships with researchers, whether your project spans weeks, months, or years. With us, you can expect long-term stability and adaptable support as your research landscape evolves.
 
   Working with CCV means you can benefit from:
@@ -19,7 +19,7 @@ links:
   
 </ContentSection>
 
-<ContentSection title="Technical Expertise">
+<ContentSection title="Technical Expertise" id="technical-expertise">
   Our team of data scientists, research software engineers, and system administrators have a broad range of technical
   expertise and scientific backgrounds (e.g., Engineering, Physics, Computer Vision, Biology, Psychology, Statistics,
   Applied Math, Computer Science, etc.) to support your research needs.
@@ -55,7 +55,7 @@ links:
   </CardGroup>
 </ContentSection>
 
-<ContentSection title="Funding Collaborations">
+<ContentSection title="Funding Collaborations" id="funding-collaborations">
   Funding for our collaborations have been supported by multiple sources including grants, gifts, faculty start-up 
   funds, and industry collaborations. Our team is available to discuss your ideas no matter where you are in the 
   project lifecycle, from initial concept to final execution. We can also help strengthen your proposals and scale 
@@ -76,7 +76,7 @@ links:
 
 </ContentSection>
 
-<ContentSection title="Project Cost Estimation">
+<ContentSection title="Project Cost Estimation" id="project-cost-estimation">
   We try to tailor our recommendations to fit within the project’s requirements, timeline, and funding. The project cost estimations below provide a rough idea of the time, effort, and cost involved for various project sizes. Feel free to chat with us at any stage of your project; we are open to discussing alternative pay structures or finding a solution that works for all parties. 
   <CardGroup>
       <CostEstimateCard 
@@ -113,7 +113,7 @@ links:
         to calculate cost.
 </ContentSection>
 
-<ContentSection title="Project Estimation Examples">
+<ContentSection title="Project Estimation Examples" id="project-estimation-examples">
   <ProjectEstimationSection/>
 </ContentSection>
 

--- a/content/services/rates.mdx
+++ b/content/services/rates.mdx
@@ -3,7 +3,7 @@ title: Rates
 description: We provide services with limited resources at no cost to all members affiliated with Brown. For advanced computing that requires extra resources, we charge a monthly fee.
 ---
 
-<ContentSection title="High Performance Computing Cluster (Oscar)">
+<ContentSection title="High Performance Computing Cluster (Oscar)" id="hpc">
 
 The number and size of jobs allowed on Oscar vary with both partition and type of user account.
 All Brown users can request a free exploratory account with basic access to a resources on our Batch and GPU partitions.
@@ -113,7 +113,7 @@ would result in double the walltime at 192 hours (19,968 / 104).
 
 </ContentSection>
 
-<ContentSection title="Purchasing a Condo">
+<ContentSection title="Purchasing a Condo" id="condo">
 
 A condo is an account that gives users priority access to computing resources, specifically CPU cores and GPU resources. 
 Investigators may purchase condos to share access to computing resources with their team.
@@ -127,7 +127,7 @@ Investigators may purchase condos to share access to computing resources with th
 
 </ContentSection>
 
-<ContentSection title="Research Data Storage">
+<ContentSection title="Research Data Storage" id="research-data-storage">
 
 ### Brown Sponsored Allocation
 
@@ -177,7 +177,7 @@ We are able to accommodate group payment plans where individual and grant alloca
 
 </ContentSection>
 
-<ContentSection title="Contact Us">
+<ContentSection title="Contact Us" id="contact-us">
 
 Have questions about our resources & rates or ready to upgrade your account? CCV can help! We offer consultations to determine the most cost-effective resources for your research needs.
 

--- a/content/services/stronghold.mdx
+++ b/content/services/stronghold.mdx
@@ -4,7 +4,7 @@ description: |
   A secure computing and storage environment that enables Brown researchers to analyze sensitive data while complying with regulatory or contractual requirements.
 ---
 
-<ContentSection title="Why Use Highly Secure Computing?">
+<ContentSection title="Why Use Highly Secure Computing?" id="why-stronghold">
 Stronghold is a secure computing and storage environment that allows Brown researchers to analyze sensitive data while
 meeting regulatory and contractual requirements. It adheres to federal and Rhode Island laws for data privacy and
 protection. If you work with Level 3 Data, which includes personally identifiable information (PII) such as names,
@@ -17,7 +17,7 @@ can access remotely. Workstations come with standard software packages but can b
 research needs.
 </ContentSection>
 
-<ContentSection title="Security Features">
+<ContentSection title="Security Features" id="security-features">
 <CardGroup>
   <StyledCard size="lg" iconName="FaArrowsAltH" title="Secure Data Exchange">
     Download data from whitelisted agencies via HTTPS and SFTP. A secure transfer service scans files for viruses and
@@ -56,7 +56,7 @@ research needs.
 </CardGroup>
 </ContentSection>
 
-<ContentSection title="Is Stronghold Right for You?">
+<ContentSection title="Is Stronghold Right for You?" id="is-stronghold-right-for-you">
 Stronghold is for you if you work with Level 3 Data,
 which includes personally identifiable information (PII) such as names, addresses, and dates of birth, or Protected Health
 Information (PHI) like medical records and billing information. It is also suitable for handling restricted research
@@ -71,10 +71,9 @@ As a Principal Investigator, you can begin using Stronghold for your research by
 </Button>
 </ButtonGroup>
 
-
 </ContentSection>
 
-<ContentSection title="Contact Us">
+<ContentSection title="Contact Us" id="contact-us">
 
 Need help determining if your research data requires Stronghold's secure environment? CCV can help! We offer consultations to assess your data classification requirements and determine if Stronghold is the right solution for your data privacy needs.
 

--- a/content/services/virtual-machine-hosting.mdx
+++ b/content/services/virtual-machine-hosting.mdx
@@ -11,7 +11,7 @@ and install your own software without interfering with other systems or users. V
 for researchers with needs not met by existing resources.
 </ContentSection>
 
-<ContentSection title="Is a VM Right for you?" is="is-a-vm-right-for-you">
+<ContentSection title="Is a VM Right for you?" id="is-a-vm-right-for-you">
 <TwoColumns items={[
 "**A VM may be the right choice for your research if you:** \n  - Do not want to purchase and maintain your own hardware \n - Require Windows-specific applications unavailable on your computer \n  - Use GUI-based software that is not compatible with available hardware \n  - Require persistent services and long-running tasks that cannot be hosted on other resources or platforms \n  - Want an isolated sandbox to develop and test software \n  - Need a complex software stack",
 "**A VM may not be needed if:**  \n - Your software is able to run on our computing cluster, OSCAR  \n - Your long running application or website can be hosted on an alternative resource available to Brown like Kubernetes or cloud-based hosting."

--- a/content/services/virtual-machine-hosting.mdx
+++ b/content/services/virtual-machine-hosting.mdx
@@ -4,23 +4,21 @@ description: |
   We provide and maintain virtual machine hosting free of charge for departments or researchers who need access to a server.
 ---
 
-<ContentSection title="What is a Virtual Machine?">
+<ContentSection title="What is a Virtual Machine?" id="why-vm">
 A virtual machine (VM) instance is a digital version of a computer, hosted on Brown's servers, that provides
 researchers with a dedicated and customizable environment. On a dedicated VM you can run a specific operating system
 and install your own software without interfering with other systems or users. VMs for Windows or Linux are available
 for researchers with needs not met by existing resources.
 </ContentSection>
-<ContentSection title="Is a VM Right for you?">
 
+<ContentSection title="Is a VM Right for you?" is="is-a-vm-right-for-you">
 <TwoColumns items={[
 "**A VM may be the right choice for your research if you:** \n  - Do not want to purchase and maintain your own hardware \n - Require Windows-specific applications unavailable on your computer \n  - Use GUI-based software that is not compatible with available hardware \n  - Require persistent services and long-running tasks that cannot be hosted on other resources or platforms \n  - Want an isolated sandbox to develop and test software \n  - Need a complex software stack",
 "**A VM may not be needed if:**  \n - Your software is able to run on our computing cluster, OSCAR  \n - Your long running application or website can be hosted on an alternative resource available to Brown like Kubernetes or cloud-based hosting."
 ]}/>
-
 </ContentSection>
 
-
-<ContentSection title="Contact Us">
+<ContentSection title="Contact Us" id="contact-us">
 
 VMs can be a great tool, but there are many resources at Brown that may be better alternatives for your research.
 Confused about what tools are best for your use case? CCV can help! Request a consultation with CCV to see if VMs

--- a/content/services/workshops.mdx
+++ b/content/services/workshops.mdx
@@ -5,8 +5,7 @@ description: |
   our computational resources and learn new techniques for research computing.
 ---
 
-
-<ContentSection title="Workshops & Tutorials">
+<ContentSection title="Workshops & Tutorials" id="workshops-and-tutorials">
 We offer workshops and tutorials to help you employ research computing best practices and get the most out of our systems.
   <CardGroup>
       <StyledCard
@@ -35,7 +34,7 @@ We offer workshops and tutorials to help you employ research computing best prac
   </CardGroup>
 </ContentSection>
 
-<ContentSection title="Contact Us">
+<ContentSection title="Contact Us" id="contact-us">
   Have questions about our workshops and tutorials or have suggestions for future topics? We'd love to hear from you!
 
   <Button href="/about/help#contact-us" external={false}>Contact Us</Button>

--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -30,11 +30,12 @@ const withNotProse = <T extends { className?: string }>(
 const MDXContentSection = ({
   title,
   children,
+  ...props
 }: {
   title: string
   children: React.ReactNode
-}) => (
-  <ContentSection>
+} & React.HTMLAttributes<HTMLDivElement>) => (
+  <ContentSection {...props}>
     <ContentHeader>
       <ContentTitle className="not-prose" title={title} />
     </ContentHeader>


### PR DESCRIPTION
Previously going to `/about/help#contact-us` didn't actually go to the section. Turns out the mdx version of the content section did not pass props (such as the `id`). This PR fixes that and updates ids for content sections