### PR TITLE
fix: swipe carousel trigger

### DIFF
--- a/components/carousel/SwipeCarousel.tsx
+++ b/components/carousel/SwipeCarousel.tsx
@@ -112,10 +112,10 @@ const Cards = ({ StyledCarouselItems, cardIndex }: CardsProps) => {
                   alt={item.alt}
                 />
                 <StyledDialog>
-                  <StyledDialogTrigger
-                    className="m-3 flex w-auto items-start justify-between gap-2 rounded-xl bg-slate-100 px-3 py-2 hover:bg-slate-200"
-                  >
-                    <h3 className="min-w-0 flex-1 break-words text-left font-bold">{item.title}</h3>
+                  <StyledDialogTrigger className="m-3 flex w-auto items-start justify-between gap-2 rounded-xl bg-slate-100 px-3 py-2 hover:bg-slate-200">
+                    <h3 className="min-w-0 flex-1 break-words text-left font-bold">
+                      {item.title}
+                    </h3>
                     <RenderIcon iconName="FaEllipsisV" />
                   </StyledDialogTrigger>
                   <StyledDialogCard {...item} />

--- a/components/carousel/SwipeCarousel.tsx
+++ b/components/carousel/SwipeCarousel.tsx
@@ -100,7 +100,7 @@ const Cards = ({ StyledCarouselItems, cardIndex }: CardsProps) => {
               scale: cardIndex === idx ? 0.95 : 0.85,
             }}
             transition={SPRING_OPTIONS}
-            className="w-screen shrink-0 rounded-xl bg-neutral-800 object-cover"
+            className="w-full shrink-0 rounded-xl bg-neutral-800 object-cover"
           >
             <Card className="bg-white">
               <CardContent className="flex flex-col p-0">
@@ -113,21 +113,14 @@ const Cards = ({ StyledCarouselItems, cardIndex }: CardsProps) => {
                 />
                 <StyledDialog>
                   <StyledDialogTrigger
-                    asChild
-                    className="mx-3 flex items-center justify-between px-3"
+                    className="m-3 flex w-auto items-start justify-between gap-2 rounded-xl bg-slate-100 px-3 py-2 hover:bg-slate-200"
                   >
-                    <Button
-                      variant="unstyled"
-                      aria-label="More Details"
-                      className="rounded-xl bg-slate-100"
-                    >
-                      <h3 className="font-bold">{item.title}</h3>
-                      <RenderIcon iconName="FaEllipsisV" />
-                    </Button>
+                    <h3 className="min-w-0 flex-1 break-words text-left font-bold">{item.title}</h3>
+                    <RenderIcon iconName="FaEllipsisV" />
                   </StyledDialogTrigger>
                   <StyledDialogCard {...item} />
                 </StyledDialog>
-                <div className="hidden px-3 md:line-clamp-2">
+                <div className="hidden break-words px-3 md:line-clamp-2">
                   <Markdown
                     remarkPlugins={[remarkGfm]}
                     rehypePlugins={[rehypeRaw]}
@@ -182,11 +175,11 @@ const StyledDialogCard = ({
           </Markdown>
         </div>
       )}
-      <StyledDialogTitle className="pt-4 text-center text-xl font-bold">
+      <StyledDialogTitle className="break-words pt-4 text-center text-xl font-bold">
         {title}
       </StyledDialogTitle>
       {/* Content */}
-      <div className="flex flex-col items-center gap-10 px-8">
+      <div className="flex flex-col items-center gap-10 break-words px-8">
         {/* Organizations */}
         {organizations && organizations.length > 0 && (
           <div


### PR DESCRIPTION
* Fixes width of the swipe dialog trigger to use w-full and w-auto
* Fixes dialog title overflow to break words if long
* Also made an issue for #482 which is not fixed in this PR. Motivation for this PR was to take out the use of `<Button>`
<img width="404" height="699" alt="Screenshot 2026-01-07 at 7 31 24 PM" src="https://github.com/user-attachments/assets/54797e21-b65d-44f4-96e3-79773c706309" />

# Previously
<img width="250" alt="Screenshot 2026-01-07 at 7 32 14 PM" src="https://github.com/user-attachments/assets/aa14075f-4426-423a-bb69-bca06452ca10" /> <img width="250" alt="Screenshot 2026-01-07 at 7 32 00 PM" src="https://github.com/user-attachments/assets/e6d6582a-e07c-4270-b172-e766912b93b3" />
