### PR TITLE
fix: monthly calendar date

### DIFF
--- a/components/calendar/CalendarMonth.tsx
+++ b/components/calendar/CalendarMonth.tsx
@@ -21,7 +21,7 @@ import {
   getDate,
   isSameDay,
   getWeeksInMonth,
-  format
+  format,
 } from "date-fns"
 import { CalendarHeading } from "@/components/calendar/CalendarHeading"
 import { DataProps } from "@/components/EventSection"

--- a/components/calendar/CalendarMonth.tsx
+++ b/components/calendar/CalendarMonth.tsx
@@ -21,6 +21,7 @@ import {
   getDate,
   isSameDay,
   getWeeksInMonth,
+  format
 } from "date-fns"
 import { CalendarHeading } from "@/components/calendar/CalendarHeading"
 import { DataProps } from "@/components/EventSection"
@@ -118,7 +119,9 @@ const CalendarMonth: React.FC<CalendarProps> = ({
               </Button>
             </PopoverTrigger>
             <PopoverContent className="bg-neutral-50">
-              <p className="pb-2 font-semibold">{event.date}</p>
+              <p className="pb-2 font-semibold">
+                {format(new Date(event.date_utc), "MMMM d, yyyy")}
+              </p>
               <ButtonLink
                 href={event.url}
                 external={true}


### PR DESCRIPTION
Last year's monthly dates were not displaying correctly this is the fix.

Previously
<img width="383" height="406" alt="Screenshot 2026-01-12 at 9 42 54 AM" src="https://github.com/user-attachments/assets/851aaa63-31fb-4646-b74d-6a41b9deccad" />

This PR
<img width="324" height="332" alt="Screenshot 2026-01-12 at 9 43 23 AM" src="https://github.com/user-attachments/assets/8baa0819-514f-4871-a0f6-b335ef84791c" />
