### PR TITLE
fix: meilisearch official meili-master-key

### DIFF
--- a/.github/workflows/deploy-meilisearch.yaml
+++ b/.github/workflows/deploy-meilisearch.yaml
@@ -27,7 +27,7 @@ jobs:
             --platform managed \
             --region us-central1 \
             --allow-unauthenticated \
-            --set-env-vars MEILISEARCH_MASTER_KEY=${{ secrets.MEILISEARCH_MASTER_KEY }} \
+            --set-env-vars MEILI_MASTER_KEY=${{ secrets.MEILISEARCH_MASTER_KEY }} \
             --memory 1Gi \
             --cpu 1 \
             --min-instances 1 \


### PR DESCRIPTION
Per the docs, Environment variables are always identical to the corresponding command-line option, but prepended with MEILI_ and written in all uppercase. Oops