### PR TITLE
feat: add section to help for accessibility form

### DIFF
--- a/components/button/variants.tsx
+++ b/components/button/variants.tsx
@@ -1,7 +1,7 @@
 import { cva } from "class-variance-authority"
 
 export const ButtonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-full text-md font-bold transition-colors focus-visible:outline-none focus-visible:ring-ring focus:outline-none focus-visible:ring-2 focus-visible:ring-sunglow-400 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+  "inline-flex text-center flex-wrap items-center justify-center gap-2 rounded-full text-md font-bold transition-colors focus-visible:outline-none focus-visible:ring-ring focus:outline-none focus-visible:ring-2 focus-visible:ring-sunglow-400 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
   {
     variants: {
       variant: {
@@ -60,11 +60,11 @@ export const ButtonVariants = cva(
       },
 
       size: {
-        sm: "h-8 px-4 py-2 text-sm",
-        md: "h-10 px-5 py-2.5 text-md",
-        lg: "h-12 px-6 py-3 text-lg",
-        xl: "h-14 px-8 py-4 text-xl",
-        xxl: "h-16 px-10 py-5 text-2xl",
+        sm: "min-h-8 px-4 py-2 text-sm",
+        md: "min-h-10 px-5 py-2.5 text-md",
+        lg: "min-h-12 px-6 py-3 text-lg",
+        xl: "min-h-14 px-8 py-4 text-xl",
+        xxl: "min-h-16 px-10 py-5 text-2xl",
 
         // large icon-only
         icon: "w-10 h-10",

--- a/content/routes/about/help.mdx
+++ b/content/routes/about/help.mdx
@@ -69,6 +69,7 @@ category: about
 
     </CardGroup>
 </ContentSection>
+
 <ContentSection title="Report an Accessibility Concern" id="accessibility">
     If you encounter digital content that you are unable to access due to an accessibility issue, please use this digital accessibility concern reporting form to report the issue:
 

--- a/content/routes/about/help.mdx
+++ b/content/routes/about/help.mdx
@@ -69,7 +69,7 @@ category: about
 
     </CardGroup>
 </ContentSection>
-<ContentSection title="Report an Accessibility Concern">
+<ContentSection title="Report an Accessibility Concern" id="accessibility">
 If you encounter digital content that you are unable to access due to an accessibility issue, please use this digital accessibility concern reporting form to report the issue:
 
     <Button href="https://cm.maxient.com/reportingform.php?BrownUniv=&layout_id=59">Digital Accessibility Concern Reporting Form</Button>

--- a/content/routes/about/help.mdx
+++ b/content/routes/about/help.mdx
@@ -69,3 +69,8 @@ category: about
 
     </CardGroup>
 </ContentSection>
+<ContentSection title="Report an Accessibility Concern">
+If you encounter digital content that you are unable to access due to an accessibility issue, please use this digital accessibility concern reporting form to report the issue:
+
+    <Button href="https://cm.maxient.com/reportingform.php?BrownUniv=&layout_id=59">Digital Accessibility Concern Reporting Form</Button>
+</ContentSection>

--- a/content/routes/about/help.mdx
+++ b/content/routes/about/help.mdx
@@ -70,7 +70,7 @@ category: about
     </CardGroup>
 </ContentSection>
 <ContentSection title="Report an Accessibility Concern" id="accessibility">
-If you encounter digital content that you are unable to access due to an accessibility issue, please use this digital accessibility concern reporting form to report the issue:
+    If you encounter digital content that you are unable to access due to an accessibility issue, please use this digital accessibility concern reporting form to report the issue:
 
     <Button href="https://cm.maxient.com/reportingform.php?BrownUniv=&layout_id=59">Digital Accessibility Concern Reporting Form</Button>
 </ContentSection>


### PR DESCRIPTION
Adds a content section in the about/help route to the accessibility reporting form. Uses language identical to the https://digital-accessibility.brown.edu/ page. The accessibility link in the footer also goes to the https://digital-accessibility.brown.edu/ page already