### PR TITLE
chore: non-replicated

### DIFF
--- a/content/routes/services/rates.mdx
+++ b/content/routes/services/rates.mdx
@@ -133,28 +133,30 @@ Investigators may purchase condos to share access to computing resources with th
 
 ### Brown Sponsored Allocation
 
-CCV provides several storage options for research data. Brown Faculty members are allocated 1TB of default storage with 
-an additional 10TB per active grant.
+CCV provides several storage options for research data. Brown Faculty members are allocated 1TB of default storage. With
+an active grant, researchers are allocated an additional 10TB on replicated storage or 20TB of non-replicated storage.
 <CardGroup>
   <StyledCard title="Basic" size="md" headerColor="basic">
     - **Location:** Oscar, Campus Files, Stronghold
     - **Storage:** 1TB
-    - **Cost:** $0/year
+    - **Cost:** $0
   </StyledCard>
 
   <StyledCard title="Active Grant Allocation" size="md" headerColor="plus">
       - **Location:** Oscar, Campus Files, Stronghold
       - **Storage:** 10TB
-      - **Cost:** $0 (per 10TB/grant)
+      - **Cost:** $0
+
+      (10TB/grant on replicated or 20TB/grant on non-replicated)
     </StyledCard>
 </CardGroup>
 
 ### Additional Research Storage
-Additional research storage can be purchased. Purchased storage is available in two types: Unreplicated (a single copy) 
+Additional research storage can be purchased. Purchased storage is available in two types: Non-replicated (a single copy)
 or Replicated (multiple copies at different locations). 
 
 <CardGroup>
-  <StyledCard title="Unreplicated" size="md" headerColor="premium">
+  <StyledCard title="Non-replicated" size="md" headerColor="premium">
     - **Location:** Campus Files
     - **Storage:** User-specified
     - **Cost:** $50/TB/year

--- a/content/routes/services/rates.mdx
+++ b/content/routes/services/rates.mdx
@@ -142,13 +142,18 @@ an active grant, researchers are allocated an additional 10TB on replicated stor
     - **Cost:** $0
   </StyledCard>
 
-  <StyledCard title="Active Grant Allocation" size="md" headerColor="plus">
+  <StyledCard title="Active Grant Allocation: Non-replicated" size="md" headerColor="plus">
+          - **Location:** Campus Files
+          - **Storage:** 20TB
+          - **Cost:** $0
+    </StyledCard>
+
+  <StyledCard title="Active Grant Allocation: Replicated" size="md" headerColor="plus">
       - **Location:** Oscar, Campus Files, Stronghold
       - **Storage:** 10TB
       - **Cost:** $0
+  </StyledCard>
 
-      (10TB/grant on replicated or 20TB/grant on non-replicated)
-    </StyledCard>
 </CardGroup>
 
 ### Additional Research Storage


### PR DESCRIPTION
This PR fixes inconsistency of definitions on the rates page. "Unreplicated" is now "Non-replicated". I did a project-wide search for "unreplicated" and didn't find anything else!

We now also make it more clear that with "an active grant, researchers are allocated an additional 10TB on replicated storage or 20TB of non-replicated storage."

closes #536 