### PR TITLE
refactor: remove rates from table

### DIFF
--- a/app/services/file-storage-and-transfer/page.tsx
+++ b/app/services/file-storage-and-transfer/page.tsx
@@ -44,6 +44,13 @@ export default async function CompareStorageOptions() {
         >
           Storage Help
         </ButtonLink>
+        <ButtonLink
+          variant="primary_filled"
+          size="lg"
+          href="/services/rates#research-data-storage"
+        >
+          Storage Rates
+        </ButtonLink>
         <ScrollButton
           variant="primary_filled"
           size="lg"

--- a/components/storage/StorageTable.tsx
+++ b/components/storage/StorageTable.tsx
@@ -202,15 +202,9 @@ export function StorageTable({ services }: TableProps) {
         {
           id: featureName,
           header: () => (
-            <div className="flex items-center justify-center gap-2.5">
-              <Icon
-                iconName={metadata?.icon}
-                className="h-4 w-4 flex-shrink-0"
-              />
-              <p className="text-sm font-medium uppercase">
-                {metadata.display_name}
-              </p>
-            </div>
+            <p className="text-sm font-medium uppercase">
+              {metadata.display_name}
+            </p>
           ),
           cell: (info) => {
             const feature = info.row.original[featureName] as ServiceFeature
@@ -310,9 +304,9 @@ export function StorageTable({ services }: TableProps) {
                       style={{ ...getCommonPinningStyles(column) }}
                       onClick={header.column.getToggleSortingHandler()}
                     >
-                      <div className="flex items-center justify-between gap-5">
+                      <div className="flex items-center gap-3">
                         {!header.isPlaceholder && header.column.getCanPin() && (
-                          <div className="pb-2">
+                          <div>
                             {header.column.getIsPinned() !== "left" ? (
                               <Button
                                 variant="icon_only"

--- a/content/data/storage-features.json
+++ b/content/data/storage-features.json
@@ -175,11 +175,7 @@
         "name": "storage_threshold",
         "value": "2 TB +",
         "sortValue": 2000,
-        "notes": [
-          "2 TB per PI",
-          "20 TB per grant",
-          "Paid after that @ $50/TB/Yr. (Summed across all paid storage types)"
-        ]
+        "notes": ["2 TB per PI", "20 TB per grant"]
       },
       "max_file_size": {
         "name": "max_file_size",
@@ -263,11 +259,7 @@
         "name": "storage_threshold",
         "value": "1 TB +",
         "sortValue": 1000,
-        "notes": [
-          "1 TB per PI",
-          "10 TB per grant",
-          "Paid after that @ $100/TB/Yr. (Summed across all paid storage types)"
-        ]
+        "notes": ["1 TB per PI", "10 TB per grant"]
       },
       "max_file_size": {
         "name": "max_file_size",
@@ -519,11 +511,7 @@
         "name": "storage_threshold",
         "value": "1 TB +",
         "sortValue": 1000,
-        "notes": [
-          "1 TB per PI",
-          "10 TB per grant",
-          "Paid after that @ $100/TB/Yr. (Summed across all paid storage types)"
-        ]
+        "notes": ["1 TB per PI", "10 TB per grant"]
       },
       "max_file_size": {
         "name": "max_file_size",
@@ -607,11 +595,7 @@
         "name": "storage_threshold",
         "value": "1 TB +",
         "sortValue": 1000,
-        "notes": [
-          "1 TB per PI",
-          "10 TB per grant",
-          "Paid after that @ $100/TB/Yr. (Summed across all paid storage types)"
-        ]
+        "notes": ["1 TB per PI", "10 TB per grant"]
       },
       "max_file_size": {
         "name": "max_file_size",

--- a/content/data/storage-features.json
+++ b/content/data/storage-features.json
@@ -175,7 +175,7 @@
         "name": "storage_threshold",
         "value": "2 TB +",
         "sortValue": 2000,
-        "notes": ["2 TB per PI", "20 TB per grant"]
+        "notes": null
       },
       "max_file_size": {
         "name": "max_file_size",
@@ -259,7 +259,7 @@
         "name": "storage_threshold",
         "value": "1 TB +",
         "sortValue": 1000,
-        "notes": ["1 TB per PI", "10 TB per grant"]
+        "notes": null
       },
       "max_file_size": {
         "name": "max_file_size",
@@ -511,7 +511,7 @@
         "name": "storage_threshold",
         "value": "1 TB +",
         "sortValue": 1000,
-        "notes": ["1 TB per PI", "10 TB per grant"]
+        "notes": null
       },
       "max_file_size": {
         "name": "max_file_size",
@@ -595,7 +595,7 @@
         "name": "storage_threshold",
         "value": "1 TB +",
         "sortValue": 1000,
-        "notes": ["1 TB per PI", "10 TB per grant"]
+        "notes": null
       },
       "max_file_size": {
         "name": "max_file_size",


### PR DESCRIPTION
This PR removes rates information from the table data and removes icons from table column th. Adds an action button to view rates info, links to the storage rates section of the rates page