### PR TITLE
feat: storage documentation links

### DIFF
--- a/content/routes/services/file-storage-and-transfer.mdx
+++ b/content/routes/services/file-storage-and-transfer.mdx
@@ -42,24 +42,51 @@ Several services at Brown allow you to share and store files. These different st
     - Best for: High performance storage of research data, perform computation on your data using Brown’s supercomputer
     - Limitations: Not accessible on all campus networks.
     - Synonyms: Oscar Data, HPC Storage, GPFS (historically)
+
+    <ButtonGroup>
+        <Button href="/services/oscar">About Oscar</Button>
+        <Button
+          variant="secondary_filled"
+          href="https://brown.co1.qualtrics.com/jfe/form/SV_0GtBE8kWJpmeG4B"
+        >
+          Request an Account
+        </Button>
+    </ButtonGroup>
     </AccordionItem>
 
     <AccordionItem title="Stronghold" id="stronghold">
     Stronghold is a secure computing and storage environment that enables Brown researchers to analyze sensitive data while complying with regulatory or contractual requirements.
 
     - Best for: Storing data with data usage agreements, FISMA, etc.
+
+    <ButtonGroup>
+        <Button href="/services/stronghold">About Stronghold</Button>
+        <Button
+            variant="secondary_filled"
+            href="https://brown.atlassian.net/servicedesk/customer/portal/22/group/62/create/256"
+        >
+            Request Environment
+        </Button>
+    </ButtonGroup>
     </AccordionItem>
 
     <AccordionItem title="Hibernate" id="hibernate">
     Hibernate is a secure, reliable, research data archive solution. Hibernate is a Brown OIT archival service for the research community to migrate inactive data off active Network-attached storage (NAS) platforms onto a lower cost, long-term retention environment.
+    
+    <ButtonGroup>
+        <Button href="https://docs.ccv.brown.edu/hibernate">Documentation</Button>
+    </ButtonGroup>
     </AccordionItem>
 
     <AccordionItem title="Lab Archives" id="lab-archives">
     Lab Archives is a cloud-based electronic lab notebook that can be used by researchers, instructors, and students for input and organization of laboratory data, information sharing, and collaboration, and for saving historical versions of files. It is appropriate for use in a wide variety of laboratories, including biological sciences, chemistry and physical sciences, and engineering, among others.
 
     - Best for: LabArchives at Brown provides unlimited storage space. The current size limit per file is 4GB.
-
     - Limitations: LabArchives at Brown is not approved for storing files containing Personally Identifiable Information (PII), Protected Health Information (PHI), or Brown Restricted Information.
+    
+    <ButtonGroup>
+        <Button href="https://libguides.brown.edu/data_management">Documentation</Button>
+    </ButtonGroup>
     </AccordionItem>
 
     <AccordionItem title="Brown Digital Repository" id="bdr">
@@ -74,6 +101,10 @@ Several services at Brown allow you to share and store files. These different st
     - Data curation, format migration, and preservation services.
 
     Faculty and researchers interested in using the Brown Digital Repository as a platform for programmatic data management, storage, and publication should contact the Library (bdr@brown.edu) for information about opportunities for research consulting and project development support.
+    
+    <ButtonGroup>
+        <Button href="https://repository.library.brown.edu/studio/about">Documentation</Button>
+    </ButtonGroup>
     </AccordionItem>
 
     <AccordionItem title="Google Drive" id="google-drive">


### PR DESCRIPTION
closes #542 

<img width="2656" height="1511" alt="Screenshot of documentation links for storage options" src="https://github.com/user-attachments/assets/4178a980-da45-4101-97fd-a1486ea1b434" />
