### PR TITLE
feat: use title to determine id for each content section

### DIFF
--- a/app/about/careers/page.tsx
+++ b/app/about/careers/page.tsx
@@ -1,10 +1,6 @@
 import React from "react"
 import { Hero } from "@/components/Hero"
-import {
-  ContentHeader,
-  ContentSection,
-  ContentTitle,
-} from "@/components/ContentSection"
+import { ContentSection } from "@/components/ContentSection"
 import { ButtonLink } from "@/components/button/ButtonLink"
 import CareersContent from "@/content/routes/about/careers.mdx"
 import { CareerData } from "@/components/CareerData"

--- a/app/about/careers/page.tsx
+++ b/app/about/careers/page.tsx
@@ -27,10 +27,7 @@ export default async function Careers() {
           Contact Us
         </ButtonLink>
       </Hero>
-      <ContentSection className="bg-neutral-50" id="opportunities">
-        <ContentHeader>
-          <ContentTitle title="Opportunities" />
-        </ContentHeader>
+      <ContentSection title="Opportunities" className="bg-neutral-50">
         <CareerData />
       </ContentSection>
       <CareersContent />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,7 +13,6 @@ import {
   ContentHeader,
   ContentSection,
   ContentSubHeader,
-  ContentTitle,
 } from "@/components/ContentSection"
 import { FaCalendarAlt } from "react-icons/fa"
 import { getMDXMetadata } from "@/lib/mdx-utils"
@@ -48,15 +47,11 @@ export default async function Home() {
         <HeroCard />
         <ImpactBanner />
         <div>
-          <ContentSection className="px-none">
-            <ContentHeader>
-              <ContentTitle title="Featured Projects" />
-            </ContentHeader>
+          <ContentSection title="Featured Projects" className="px-none">
             <FeaturedCarousel carouselData={featuredCarouselData} />
           </ContentSection>
-          <ContentSection id="events" align="left">
+          <ContentSection title="Events" icon={<FaCalendarAlt />} align="left">
             <ContentHeader>
-              <ContentTitle title="Events" icon={<FaCalendarAlt />} />
               <ContentSubHeader>
                 <>
                   <h3 className="font-serif font-normal italic">

--- a/app/services/classroom/page.tsx
+++ b/app/services/classroom/page.tsx
@@ -4,11 +4,7 @@ import { getMDXMetadata } from "@/lib/mdx-utils"
 import { FeaturedCarousel } from "@/components/carousel/FeaturedCarousel"
 import classroomCarousel from "@/content/data/classroom-carousel.json"
 import { StyledCarouselItem } from "@/components/carousel/StyledCarousel"
-import {
-  ContentHeader,
-  ContentSection,
-  ContentTitle,
-} from "@/components/ContentSection"
+import { ContentSection } from "@/components/ContentSection"
 
 export default async function ClassroomSupport() {
   const metadata = getMDXMetadata("content/routes/services/classroom.mdx")

--- a/app/services/classroom/page.tsx
+++ b/app/services/classroom/page.tsx
@@ -17,10 +17,10 @@ export default async function ClassroomSupport() {
   return (
     <>
       <Hero title={metadata.title} description={metadata.description} />
-      <ContentSection className="px-none bg-neutral-50" id="in-class-tutorials">
-        <ContentHeader>
-          <ContentTitle title="In-Class Tutorials" />
-        </ContentHeader>
+      <ContentSection
+        title="In-Class Tutorials"
+        className="px-none bg-neutral-50"
+      >
         <p className="px-page">
           CCV offers a variety of tutorials to provide students with experience
           using Brown's HPC systems. CCV staff members provide students with an

--- a/app/services/file-storage-and-transfer/page.tsx
+++ b/app/services/file-storage-and-transfer/page.tsx
@@ -50,7 +50,7 @@ export default async function CompareStorageOptions() {
         <ScrollButton
           variant="primary_filled"
           size="lg"
-          id="table"
+          id="compare-storage-options"
           className={TABLE_VISIBILITY}
           aria-describedby="table-nav-desc"
           aria-label="Scroll to comparison table section"

--- a/components/ContentSection.tsx
+++ b/components/ContentSection.tsx
@@ -20,20 +20,43 @@ export function ContentSection({
 }: ContentSectionProps & React.HTMLAttributes<HTMLDivElement>) {
   const sanitizedTitle = title ? slugifyAnchor(title) : undefined
 
+  const allChildren = React.Children.toArray(children)
+
   // Separate ContentHeader children from other children
-  const contentHeaderChild = React.Children.toArray(children).find(
+  const contentHeaderChild = allChildren.find(
     (
       child
     ): child is React.ReactElement<React.HTMLAttributes<HTMLDivElement>> =>
       React.isValidElement(child) && child.type === ContentHeader
   )
-  const otherChildren = React.Children.toArray(children).filter(
+
+  const otherChildren = allChildren.filter(
     (child) => !(React.isValidElement(child) && child.type === ContentHeader)
   )
 
+  const autoTitle = title ? (
+    <ContentTitle title={title} bars={bars} icon={icon} />
+  ) : null
+
+  const renderedHeader = contentHeaderChild ? (
+    React.cloneElement(contentHeaderChild, {
+      ...contentHeaderChild.props,
+      className: cn("not-prose", contentHeaderChild.props.className),
+      children: (
+        <>
+          {autoTitle}
+          {contentHeaderChild.props.children}
+        </>
+      ),
+    })
+  ) : title ? (
+    <ContentHeader className="not-prose">{autoTitle}</ContentHeader>
+  ) : null
+
   return (
     <section
-      id={sanitizedTitle}
+      {...props}
+      id={props.id ?? sanitizedTitle}
       className={cn(
         "w-full space-y-4 px-12 py-12 even:bg-neutral-50 sm:px-16 lg:px-14 xl:px-20",
         align === "left"
@@ -42,14 +65,8 @@ export function ContentSection({
         className
       )}
       data-align={align}
-      {...props}
     >
-      {(title || contentHeaderChild) && (
-        <ContentHeader className="not-prose">
-          {title && <ContentTitle title={title} bars={bars} icon={icon} />}
-          {contentHeaderChild?.props.children}
-        </ContentHeader>
-      )}
+      {renderedHeader}
       {otherChildren}
     </section>
   )

--- a/components/ContentSection.tsx
+++ b/components/ContentSection.tsx
@@ -4,15 +4,24 @@ import { CCVBars } from "@/components/assets/CCVBars"
 
 interface ContentSectionProps {
   align?: "left" | "center"
+  title: string
+  bars?: boolean
+  icon?: React.ReactNode
 }
 
 export function ContentSection({
   align = "center",
+  title,
+  bars = true,
+  icon,
   className,
+  children,
   ...props
 }: ContentSectionProps & React.HTMLAttributes<HTMLDivElement>) {
+  const santitizedTitle = title.toLowerCase().replace(/\s+/g, "-")
   return (
     <section
+      id={santitizedTitle}
       className={cn(
         "w-full space-y-4 px-12 py-12 even:bg-neutral-50 sm:px-16 lg:px-14 xl:px-20",
         align === "left"
@@ -22,7 +31,12 @@ export function ContentSection({
       )}
       data-align={align}
       {...props}
-    />
+    >
+      <ContentHeader>
+        <ContentTitle title={title} bars={bars} icon={icon} />
+      </ContentHeader>
+      {children}
+    </section>
   )
 }
 

--- a/components/ContentSection.tsx
+++ b/components/ContentSection.tsx
@@ -45,7 +45,7 @@ export function ContentSection({
       {...props}
     >
       {(title || contentHeaderChild) && (
-        <ContentHeader>
+        <ContentHeader className="not-prose">
           {title && <ContentTitle title={title} bars={bars} icon={icon} />}
           {contentHeaderChild?.props.children}
         </ContentHeader>

--- a/components/ContentSection.tsx
+++ b/components/ContentSection.tsx
@@ -1,10 +1,10 @@
 import React from "react"
-import { cn } from "@/lib/utils"
+import { cn, slugifyAnchor } from "@/lib/utils"
 import { CCVBars } from "@/components/assets/CCVBars"
 
 interface ContentSectionProps {
   align?: "left" | "center"
-  title: string
+  title?: string
   bars?: boolean
   icon?: React.ReactNode
 }
@@ -18,10 +18,22 @@ export function ContentSection({
   children,
   ...props
 }: ContentSectionProps & React.HTMLAttributes<HTMLDivElement>) {
-  const santitizedTitle = title.toLowerCase().replace(/\s+/g, "-")
+  const sanitizedTitle = title ? slugifyAnchor(title) : undefined
+
+  // Separate ContentHeader children from other children
+  const contentHeaderChild = React.Children.toArray(children).find(
+    (
+      child
+    ): child is React.ReactElement<React.HTMLAttributes<HTMLDivElement>> =>
+      React.isValidElement(child) && child.type === ContentHeader
+  )
+  const otherChildren = React.Children.toArray(children).filter(
+    (child) => !(React.isValidElement(child) && child.type === ContentHeader)
+  )
+
   return (
     <section
-      id={santitizedTitle}
+      id={sanitizedTitle}
       className={cn(
         "w-full space-y-4 px-12 py-12 even:bg-neutral-50 sm:px-16 lg:px-14 xl:px-20",
         align === "left"
@@ -32,10 +44,13 @@ export function ContentSection({
       data-align={align}
       {...props}
     >
-      <ContentHeader>
-        <ContentTitle title={title} bars={bars} icon={icon} />
-      </ContentHeader>
-      {children}
+      {(title || contentHeaderChild) && (
+        <ContentHeader>
+          {title && <ContentTitle title={title} bars={bars} icon={icon} />}
+          {contentHeaderChild?.props.children}
+        </ContentHeader>
+      )}
+      {otherChildren}
     </section>
   )
 }

--- a/components/storage/StorageTool.tsx
+++ b/components/storage/StorageTool.tsx
@@ -47,11 +47,7 @@ export function StorageTool({ className }: StorageToolProps) {
 
   return (
     <>
-      <ContentSection id="form" className="not-prose">
-        <ContentHeader>
-          <ContentTitle title="Storage Selection Tool" />
-        </ContentHeader>
-
+      <ContentSection title="Storage Selection Tool" className="not-prose">
         <p className="mb-6 text-lg leading-tight lg:text-xl">
           Answering the questions in the form will provide a list of services
           that meet your requirements.
@@ -68,7 +64,7 @@ export function StorageTool({ className }: StorageToolProps) {
             <ScrollButton
               variant="primary_filled"
               size="md"
-              id="table"
+              id="compare-storage-options"
               aria-describedby="table-nav-desc"
               aria-label="Scroll to comparison table section"
             >
@@ -100,10 +96,10 @@ export function StorageTool({ className }: StorageToolProps) {
           />
         </div>
       </ContentSection>
-      <ContentSection id="table" className={`not-prose ${TABLE_VISIBILITY}`}>
-        <ContentHeader>
-          <ContentTitle title="Compare Storage Options" />
-        </ContentHeader>
+      <ContentSection
+        title="Compare Storage Options"
+        className={`not-prose ${TABLE_VISIBILITY}`}
+      >
         <p className="mb-6 text-lg leading-tight lg:text-xl">
           This tool lets you compare the available storage options at Brown to
           compare their features and decide which of these services best suits

--- a/components/storage/StorageTool.tsx
+++ b/components/storage/StorageTool.tsx
@@ -3,11 +3,7 @@
 import React, { useCallback, useState } from "react"
 import { Button } from "@/components/button/Button"
 import { ScrollButton } from "@/components/button/ScrollButton"
-import {
-  ContentHeader,
-  ContentSection,
-  ContentTitle,
-} from "@/components/ContentSection"
+import { ContentSection } from "@/components/ContentSection"
 import { StorageForm } from "@/components/storage/StorageForm"
 import { StorageTable } from "@/components/storage/StorageTable"
 import { TABLE_VISIBILITY } from "@/lib/styles"

--- a/content/routes/about/careers.mdx
+++ b/content/routes/about/careers.mdx
@@ -6,7 +6,7 @@ slug: about/careers
 category: about
 ---
 
-<ContentSection title="Diversity Statement" id="diversity-statement">
+<ContentSection title="Diversity Statement">
 CCV embraces a community enriched and enhanced by diverse dimensions, including race, ethnicity and national origins,
 disability status, gender and gender identity, sexuality, class and religion. We believe diversity brings innovation and
 progress. We are especially committed to increasing the representation of those populations that have been historically

--- a/content/routes/about/grant-and-publication-materials.mdx
+++ b/content/routes/about/grant-and-publication-materials.mdx
@@ -5,7 +5,7 @@ slug: about/grant-and-publication-materials
 category: about
 ---
 
-<ContentSection title="Grant Proposal Materials for CCV Collaborators" id="grant-proposal-materials">
+<ContentSection title="Grant Proposal Materials for CCV Collaborators">
   As you are preparing for a grant proposal that uses CCV resources or services, we can help provide strategic support 
   materials. 
   
@@ -37,7 +37,7 @@ category: about
   </Button>
 </ContentSection>
 
-<ContentSection title="Acknowledgment Statement" id="acknowledgement-statement">
+<ContentSection title="Acknowledgment Statement">
   Your acknowledgment helps CCV report on our impact at Brown. Clear acknowledgments help us track the impact of our services, which in turn supports continued support for our computational resources and staff.
 
   If you publish research that benefited from the use of CCV services or resources, we would greatly appreciate an acknowledgment that states:

--- a/content/routes/about/help.mdx
+++ b/content/routes/about/help.mdx
@@ -6,8 +6,8 @@ slug: about/help
 category: about
 ---
 
-<ContentSection title="Documentation" id="documentation">
-  Check out our [documentation](https://docs.ccv.brown.edu/documentation/) 
+<ContentSection title="Documentation">
+  Check out our [documentation](https://docs.ccv.brown.edu/documentation/)
   to find information and answers to common questions about using our systems.
 
   <LinkList links={[
@@ -21,7 +21,7 @@ category: about
 
 </ContentSection>
 
-<ContentSection title="Contact Us" id="contact-us">
+<ContentSection title="Contact Us">
     Need assistance?
     Please reach out to us with any questions or issues with our services or for any general inquiries.
 
@@ -70,7 +70,7 @@ category: about
     </CardGroup>
 </ContentSection>
 
-<ContentSection title="Report an Accessibility Concern" id="accessibility">
+<ContentSection title="Report an Accessibility Concern">
     If you encounter digital content that you are unable to access due to an accessibility issue, please use this digital accessibility concern reporting form to report the issue:
 
     <Button href="https://cm.maxient.com/reportingform.php?BrownUniv=&layout_id=59">Digital Accessibility Concern Reporting Form</Button>

--- a/content/routes/about/us.mdx
+++ b/content/routes/about/us.mdx
@@ -8,7 +8,7 @@ dataRefs:
     - "data/people.yaml"
 ---
 
-<ContentSection title="Office of Information Technology" id="oit">
+<ContentSection title="Office of Information Technology">
   The Center for Computation and Visualization (CCV) is a center within the
   University's central IT organization, which is the Office of Information
   Technology (OIT). In addition to building and maintaining the University's
@@ -18,7 +18,7 @@ dataRefs:
   CCV plays in OIT.
 </ContentSection>
 
-<ContentSection title="Our Mission" id="our-mission">
+<ContentSection title="Our Mission">
   We envision an environment where computational best practices, innovative
   solutions, and expert knowledge combine to build advanced tools for research
   and to enable new discoveries. Our mission is to provide the scientific and
@@ -33,7 +33,7 @@ dataRefs:
   Science, etc.), so we can closely calibrate a person with a project.
 </ContentSection>
 
-<ContentSection title="Our Team" id="our-team">
+<ContentSection title="Our Team">
   <PeopleSection peopleContentPath="content/data/people.yaml" />
 </ContentSection>
 

--- a/content/routes/ai/ai-oscar.mdx
+++ b/content/routes/ai/ai-oscar.mdx
@@ -6,7 +6,7 @@ slug: ai/ai-oscar
 category: ai
 ---
 
-<ContentSection title="GPUs on Oscar" id="gpus-on-oscar">
+<ContentSection title="GPUs on Oscar">
 
 Building modern deep learning models requires specialized hardware called graphics processing units (GPUs). Originally designed 
 for graphics rendering in computer games, GPUs' massively parallel architecture make them exceptionally well suited to the 
@@ -24,7 +24,7 @@ Oscar, from Titan RTX (24 GB VRAM) to B200 (180 GB VRAM).
 
 </ContentSection>
 
-<ContentSection title="Ollama" id="ollama">
+<ContentSection title="Ollama">
 
 Ollama is the easiest way to run large language models directly on Brown’s Oscar high‑performance computing cluster.
 Available as a preinstalled module, Ollama uses a simple client–server approach: you start a server on your allocated

--- a/content/routes/ai/ai-tools.mdx
+++ b/content/routes/ai/ai-tools.mdx
@@ -6,7 +6,7 @@ slug: ai/ai-tools
 category: ai
 ---
 
-<ContentSection title="About ChatCCV Tools" id="chatccv">
+<ContentSection title="About ChatCCV Tools">
 CCV provides access to cutting-edge AI tools and large language models through our high-performance computing
 infrastructure. Whether you need to run LLMs for research, explore AI capabilities, or integrate AI into your
 computational workflows, we have the resources and expertise to support your needs.
@@ -30,7 +30,7 @@ computational workflows, we have the resources and expertise to support your nee
   </CardGroup>
 </ContentSection>
 
-<ContentSection title="Experimental Tools" id="experimental-tools">
+<ContentSection title="Experimental Tools">
   CCV is currently developing several proof-of-concept AI tools. Ask Oscar and LibreChat are available for experimental use, though they remain in active development and may undergo changes or discontinuation. Please note that documentation may be outdated or incomplete during this development phase.
 
     * Ask Oscar is an AI assistant that specializes in answering questions about Oscar, Brown University's HPC cluster. It has access to Oscar's documentation to help you find the information you need.

--- a/content/routes/mdx-editing-guide.mdx
+++ b/content/routes/mdx-editing-guide.mdx
@@ -7,7 +7,7 @@ category: mdx
 searchable: false
 ---
 
-<ContentSection title="What is MDX?" id="what-is-mdx">
+<ContentSection title="What is MDX?">
   MDX files combine regular text and Markdown formatting with React components and custom components to create a feature-rich, flexible, and easy-to-use content editing experience.
 
   The content of the MDX Editing Guide that you are _currently reading_ is rendered from an MDX file called `mdx-editing-guide.mdx`, which you can find in the `/content` folder of the CCV website codebase. It's extremely meta.
@@ -19,7 +19,7 @@ searchable: false
   </Button>
 </ContentSection>
 
-<ContentSection title="Available Components" id="available-components">
+<ContentSection title="Available Components">
   All available components are in the `/components` folder. To make them accessible in `.mdx` files, add them to `/mdx-components.tsx`. Import the component(s) at the top of the file and add it to the Global MDX Components section at the bottom. To request a new custom component, please add an issue to the CCV website github repository.
 
   <Button href="https://github.com/brown-ccv/ccv-website/issues">
@@ -36,7 +36,7 @@ searchable: false
   2. **Test your changes** - Run `npm run dev` to see your changes
 </ContentSection>
 
-<ContentSection title="Example MDX File" id="example-mdx-file">
+<ContentSection title="Example MDX File">
   ### This is an example of an MDX content file containing custom components and markdown formatting.
 
   ```tsx
@@ -72,7 +72,7 @@ searchable: false
   ### This is how the above example renders:
 </ContentSection>
 
-<ContentSection title="Welcome to the Wonderful World of MDX" id="welcome">
+<ContentSection title="Welcome to the Wonderful World of MDX">
   The `<ContentSection>` component is used to create a header for the page and apply styling to that page's section. It is a custom component that is defined in `/components/SectionHeader.tsx` and imported in `/mdx-components.tsx`. Every section of your page should be wrapped in a `<ContentSection>` component.
 
   Insert a button that links to a markdown cheat sheet and the `@next/mdx` documentation using the `<Button/>` component. It uses the same styling as the buttons that are used throughout this website. The `<ButtonGroup/>` component is used to group buttons together.

--- a/content/routes/services/classroom.mdx
+++ b/content/routes/services/classroom.mdx
@@ -8,7 +8,7 @@ dataRefs:
     - "data/classroom-carousel.json"
 ---
 
-<ContentSection title="Student Accounts" id="student-accounts">
+<ContentSection title="Student Accounts">
 
 CCV provides access to HPC resources for classes, workshops, demonstrations, and other instructional uses. We do ask that you follow these guidelines to help us better support your class.
 
@@ -26,7 +26,7 @@ CCV provides access to HPC resources for classes, workshops, demonstrations, and
 </ButtonGroup>
 </ContentSection>
 
-<ContentSection title="Computational Notebooks" id="computational-notebooks">
+<ContentSection title="Computational Notebooks">
 
 Computational Notebooks provide a convenient, cloud-hosted way to serve Jupyter Notebooks for multiple users. Notebooks are launched within a pre-configured computing environment so that users do not need to install any software packages. This set-up free environment is ideal for courses and workshops where instructors intend for students to begin coding with minimal obstacles. Jupyter's flexibility allows instructors to pick the preferred language for a particular context, including Python, Julia, R and many more.
 
@@ -50,7 +50,7 @@ For more advanced needs, Brown's JupyterHub may be a good fit for your needs. If
 </ButtonGroup>
 </ContentSection>
 
-<ContentSection title="Contact Us" id="contact-us">
+<ContentSection title="Contact Us">
 
 Need help choosing the right computational tools for your classroom? CCV can help! We offer consultations to determine the best resources for your instructional needs.
 

--- a/content/routes/services/department-support.mdx
+++ b/content/routes/services/department-support.mdx
@@ -6,7 +6,7 @@ slug: /services/department
 category: services
 ---
 
-<ContentSection title="Collaboration Across Brown" id="collaboration-across-brown">
+<ContentSection title="Collaboration Across Brown">
 Some academic departments and centers with high demand for computational resources have invested in specialized support 
 from CCV. Our dedicated team of system engineers provides personalized service and advanced administration and 
 troubleshooting for Linux and Windows systems, web-based services, research data management, database support, and more. 
@@ -25,7 +25,7 @@ We currently provide dedicated support to the following departments:
 
 </ContentSection>
 
-<ContentSection title="Contact Us" id="contact-us">
+<ContentSection title="Contact Us">
 
 <TwoColumns items={[
 "**If you are affiliated with one of the departments listed above:** \n \n Your department has a dedicated CCV representatives to assist with your specialized needs. Please open a support ticket and specify your department to ensure your request is routed correctly.",

--- a/content/routes/services/file-storage-and-transfer.mdx
+++ b/content/routes/services/file-storage-and-transfer.mdx
@@ -8,7 +8,7 @@ dataRefs:
     - "data/storage-questions.json"
 ---
 
-<ContentSection title="Storage Options" id="definitions">
+<ContentSection title="Storage Options">
 Several services at Brown allow you to share and store files. These different storage services each have their own relative benefits and features.
 
 <Accordion type="multiple">
@@ -119,7 +119,7 @@ Several services at Brown allow you to share and store files. These different st
 
 <StorageTool/>
 
-<ContentSection title="Hibernate" id="hibernate">
+<ContentSection title="Hibernate">
 Hibernate is a secure, reliable, research data archive solution. Hibernate is a Brown OIT archival service for the research community to migrate inactive data off active Network-attached storage (NAS) platforms onto a lower cost, long-term retention environment.
 
 Hibernate leverages StarFish, an application that provides a metadata and rules-based management framework for large file systems. StarFish makes storage tiering easy: moving data, reporting, zones.
@@ -137,7 +137,7 @@ A zone is a virtual-volume or collection of branches across different file-syste
 </ButtonGroup>
 </ContentSection>
 
-<ContentSection title="Globus" id="globus">
+<ContentSection title="Globus">
 Globus is a secure, reliable, research data management service. With Globus, subscribers can move, share, and discover data via a single interface–whether your files live on a supercomputer, lab cluster, tape archive, public cloud or your laptop–you can manage this data from anywhere via just a web browser and using your existing identities. Transfers are facilitated through endpoints. Endpoints are data locations pointing to subscribers' specific datasets like a researcher's personal Google drive, research share or a folder on a computer.
 
 <Button href="https://docs.ccv.brown.edu/globus">Globus Documentation</Button>

--- a/content/routes/services/oscar.mdx
+++ b/content/routes/services/oscar.mdx
@@ -6,7 +6,7 @@ slug: /services/oscar
 category: services
 ---
 
-<ContentSection title="Why Use High-Performance Computing?" id="hpc">
+<ContentSection title="Why Use High-Performance Computing?">
 High-Performance Computing (HPC), or supercomputing, is a powerful shared resource that can dramatically accelerate and
 expand the scope of your research. Unlike a personal computer with fixed capabilities, an HPC system provides a
 customizable and scalable pool of computing resources — processors, memory, and storage — that you can tailor to the
@@ -21,7 +21,7 @@ interconnect and file system.
 </Button>
 </ContentSection>
 
-<ContentSection title="Key Benefits for Researchers" id="key-benefits">
+<ContentSection title="Key Benefits for Researchers">
 <CardGroup>
   <StyledCard size="lg" iconName="" title="Solve Problems Faster">
     Oscar resources can reduce a calculation that would take months on a personal computer to just hours or minutes.
@@ -55,7 +55,7 @@ interconnect and file system.
 </CardGroup>
 </ContentSection>
 
-<ContentSection title="Is Oscar Right for You?" id="is-oscar-right-for-you">
+<ContentSection title="Is Oscar Right for You?">
 You don't need to be an expert in computing to use these resources. Consider if any of the following apply to your work:
 
 - Does your research involve large datasets?

--- a/content/routes/services/project-consulting.mdx
+++ b/content/routes/services/project-consulting.mdx
@@ -8,7 +8,7 @@ slug: /services/project-consulting
 category: services
 ---
 
-<ContentSection title="Why Work with CCV?" id="why-ccv">
+<ContentSection title="Why Work with CCV?">
   Our team at the Center for Computation and Visualization (CCV) is composed of skilled data scientists, research software engineers, and system administrators. We believe in forming meaningful partnerships with researchers, whether your project spans weeks, months, or years. With us, you can expect long-term stability and adaptable support as your research landscape evolves.
 
   Working with CCV means you can benefit from:
@@ -21,7 +21,7 @@ category: services
   
 </ContentSection>
 
-<ContentSection title="Technical Expertise" id="technical-expertise">
+<ContentSection title="Technical Expertise">
   Our team of data scientists, research software engineers, and system administrators have a broad range of technical
   expertise and scientific backgrounds (e.g., Engineering, Physics, Computer Vision, Biology, Psychology, Statistics,
   Applied Math, Computer Science, etc.) to support your research needs.
@@ -57,8 +57,8 @@ category: services
   </CardGroup>
 </ContentSection>
 
-<ContentSection title="Funding Collaborations" id="funding-collaborations">
-  Funding for our collaborations have been supported by multiple sources including grants, gifts, faculty start-up 
+<ContentSection title="Funding Collaborations">
+  Funding for our collaborations have been supported by multiple sources including grants, gifts, faculty start-up
   funds, and industry collaborations. Our team is available to discuss your ideas no matter where you are in the 
   project lifecycle, from initial concept to final execution. We can also help strengthen your proposals and scale 
   solutions to meet your specific requirements. A full description of our facilities is available in our facilities 

--- a/content/routes/services/rates.mdx
+++ b/content/routes/services/rates.mdx
@@ -5,7 +5,7 @@ slug: /services/rates
 category: services
 ---
 
-<ContentSection title="High Performance Computing Cluster (Oscar)" id="hpc">
+<ContentSection title="High Performance Computing Cluster (Oscar)">
 
 The number and size of jobs allowed on Oscar vary with both partition and type of user account.
 All Brown users can request a free exploratory account with basic access to a resources on our Batch and GPU partitions.
@@ -115,7 +115,7 @@ would result in double the walltime at 192 hours (19,968 / 104).
 
 </ContentSection>
 
-<ContentSection title="Purchasing a Condo" id="condo">
+<ContentSection title="Purchasing a Condo">
 
 A condo is an account that gives users priority access to computing resources, specifically CPU cores and GPU resources. 
 Investigators may purchase condos to share access to computing resources with their team.
@@ -129,7 +129,7 @@ Investigators may purchase condos to share access to computing resources with th
 
 </ContentSection>
 
-<ContentSection title="Research Data Storage" id="research-data-storage">
+<ContentSection title="Research Data Storage">
 
 ### Brown Sponsored Allocation
 
@@ -186,7 +186,7 @@ We are able to accommodate group payment plans where individual and grant alloca
 
 </ContentSection>
 
-<ContentSection title="Contact Us" id="contact-us">
+<ContentSection title="Contact Us">
 
 Have questions about our resources & rates or ready to upgrade your account? CCV can help! We offer consultations to determine the most cost-effective resources for your research needs.
 

--- a/content/routes/services/stronghold.mdx
+++ b/content/routes/services/stronghold.mdx
@@ -6,7 +6,7 @@ slug: /services/stronghold
 category: services
 ---
 
-<ContentSection title="Why Use Highly Secure Computing?" id="why-stronghold">
+<ContentSection title="Why Use Highly Secure Computing?">
 Stronghold is a secure computing and storage environment that allows Brown researchers to analyze sensitive data while
 meeting regulatory and contractual requirements. It adheres to federal and Rhode Island laws for data privacy and
 protection. If you work with Level 3 Data, which includes personally identifiable information (PII) such as names,
@@ -19,7 +19,7 @@ can access remotely. Workstations come with standard software packages but can b
 research needs.
 </ContentSection>
 
-<ContentSection title="Security Features" id="security-features">
+<ContentSection title="Security Features">
 <CardGroup>
   <StyledCard size="lg" iconName="FaArrowsAltH" title="Secure Data Exchange">
     Download data from whitelisted agencies via HTTPS and SFTP. A secure transfer service scans files for viruses and
@@ -58,7 +58,7 @@ research needs.
 </CardGroup>
 </ContentSection>
 
-<ContentSection title="Is Stronghold Right for You?" id="is-stronghold-right-for-you">
+<ContentSection title="Is Stronghold Right for You?">
 Stronghold is for you if you work with Level 3 Data,
 which includes personally identifiable information (PII) such as names, addresses, and dates of birth, or Protected Health
 Information (PHI) like medical records and billing information. It is also suitable for handling restricted research
@@ -75,7 +75,7 @@ As a Principal Investigator, you can begin using Stronghold for your research by
 
 </ContentSection>
 
-<ContentSection title="Contact Us" id="contact-us">
+<ContentSection title="Contact Us">
 
 Need help determining if your research data requires Stronghold's secure environment? CCV can help! We offer consultations to assess your data classification requirements and determine if Stronghold is the right solution for your data privacy needs.
 

--- a/content/routes/services/virtual-machine-hosting.mdx
+++ b/content/routes/services/virtual-machine-hosting.mdx
@@ -6,14 +6,14 @@ slug: /services/virtual-machine-hosting
 category: services
 ---
 
-<ContentSection title="What is a Virtual Machine?" id="why-vm">
+<ContentSection title="What is a Virtual Machine?">
 A virtual machine (VM) instance is a digital version of a computer, hosted on Brown's servers, that provides
 researchers with a dedicated and customizable environment. On a dedicated VM you can run a specific operating system
 and install your own software without interfering with other systems or users. VMs for Windows or Linux are available
 for researchers with needs not met by existing resources.
 </ContentSection>
 
-<ContentSection title="Is a VM Right for you?" id="is-a-vm-right-for-you">
+<ContentSection title="Is a VM Right for you?">
 <TwoColumns items={[
 "**A VM may be the right choice for your research if you:** \n  - Do not want to purchase and maintain your own hardware \n - Require Windows-specific applications unavailable on your computer \n  - Use GUI-based software that is not compatible with available hardware \n  - Require persistent services and long-running tasks that cannot be hosted on other resources or platforms \n  - Want an isolated sandbox to develop and test software \n  - Need a complex software stack",
 "**A VM may not be needed if:**  \n - Your software is able to run on our computing cluster, OSCAR  \n - Your long running application or website can be hosted on an alternative resource available to Brown like Kubernetes or cloud-based hosting."

--- a/content/routes/services/workshops.mdx
+++ b/content/routes/services/workshops.mdx
@@ -7,7 +7,7 @@ slug: /services/workshops
 category: services
 ---
 
-<ContentSection title="Workshops & Tutorials" id="workshops-and-tutorials">
+<ContentSection title="Workshops & Tutorials">
 We offer workshops and tutorials to help you employ research computing best practices and get the most out of our systems.
   <CardGroup>
       <StyledCard
@@ -36,7 +36,7 @@ We offer workshops and tutorials to help you employ research computing best prac
   </CardGroup>
 </ContentSection>
 
-<ContentSection title="Contact Us" id="contact-us">
+<ContentSection title="Contact Us">
   Have questions about our workshops and tutorials or have suggestions for future topics? We'd love to hear from you!
 
   <Button href="/about/help#contact-us">Contact Us</Button>

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -93,3 +93,13 @@ export function urlToBreadcrumb(
   const acronymPattern = new RegExp(`\\b(${acronyms.join("|")})\\b`, "gi")
   return formatted.replace(acronymPattern, (match) => match.toUpperCase())
 }
+
+export function slugifyAnchor(raw: string): string {
+  // expects already sanitized/plain input
+  return raw
+    .toLowerCase()
+    .replace(/[^\w\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "")
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -98,8 +98,8 @@ export function slugifyAnchor(raw: string): string {
   // expects already sanitized/plain input
   return raw
     .toLowerCase()
-    .replace(/[^\w\s-]/g, "")
-    .replace(/\s+/g, "-")
-    .replace(/-+/g, "-")
-    .replace(/^-|-$/g, "")
+    .replace(/[^\w\s-]/g, "")       // Remove non-alphanumeric characters (except spaces and hyphens)
+    .replace(/\s+/g, "-")           // Replace one or more spaces with a single hyphen
+    .replace(/-+/g, "-")            // Replace multiple consecutive hyphens with a single hyphen
+    .replace(/^-|-$/g, "");         // Remove leading and trailing hyphens
 }

--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -2,11 +2,7 @@ import React from "react"
 import type { MDXComponents } from "mdx/types"
 import { cn } from "@/lib/utils"
 import Image from "next/image"
-import {
-  ContentSection,
-  ContentHeader,
-  ContentTitle,
-} from "@/components/ContentSection"
+import { ContentSection } from "@/components/ContentSection"
 import { StorageTool } from "@/components/storage/StorageTool"
 import { ButtonLink } from "@/components/button/ButtonLink"
 import { StyledCard } from "@/components/card/StyledCard"

--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -48,10 +48,7 @@ function MDXContentSection({
   children: React.ReactNode
 } & React.HTMLAttributes<HTMLDivElement>) {
   return (
-    <ContentSection {...props}>
-      <ContentHeader>
-        <ContentTitle className="not-prose" title={title} />
-      </ContentHeader>
+    <ContentSection {...props} title={title}>
       {children}
     </ContentSection>
   )


### PR DESCRIPTION
Adds a new util function, `slugifyAnchor`, which we will also use in search to create the links directly to the appropriate header sections within a page. This will ensure the id matches exactly.