### PR TITLE
gpu-he and gpu-he+ updated

### DIFF
--- a/content/routes/services/rates.mdx
+++ b/content/routes/services/rates.mdx
@@ -95,9 +95,18 @@ memory or compute throughput.
 <CardGroup>
   <StyledCard title="High-End GPU" size="md" headerColor="premium">
     - **Partition:** gpu-he
-    - **CPU Cores:** 24
-    - **Memory:** 256 GB
+    - **CPU Cores:** 56
+    - **Memory:** 784 GB
     - **GPU:** 4 High-End
+    - **Max Resource Walltime:** 96hr\*
+    - **Cost:** $133/month
+  </StyledCard>
+
+  <StyledCard title="High-End GPU+" size="md" headerColor="premium">
+    - **Partition:** gpu-he
+    - **CPU Cores:** 112
+    - **Memory:** 1568 GB
+    - **GPU:** 8 High-End
     - **Max Resource Walltime:** 96hr\*
     - **Cost:** $133/month
   </StyledCard>


### PR DESCRIPTION
The final limits:
gpu-he:    cpu=56,gres/gpu=4,mem=784G
gpu-he+:  cpu=112,gres/gpu=8,mem=1568G