### PR TITLE
fix: blank ui in search during loading

### DIFF
--- a/components/Search.tsx
+++ b/components/Search.tsx
@@ -63,8 +63,17 @@ function GroupedHits() {
     stableGroupsRef.current = sortedGroups
   }
 
+  const hasStableResults = stableGroupsRef.current.length > 0
   const displayGroups =
     status === "idle" ? sortedGroups : stableGroupsRef.current
+
+  if (!hasStableResults && (status === "stalled" || status === "loading")) {
+    return (
+      <div className="py-12 text-center">
+        <p className="text-sm text-slate-700">Loading results...</p>
+      </div>
+    )
+  }
 
   return (
     <div className="space-y-2">
@@ -102,15 +111,7 @@ function SearchResults() {
     )
   }
 
-  if (hasQuery && status === "stalled") {
-    return (
-      <div className="py-12 text-center">
-        <p className="text-sm text-slate-700">Loading results...</p>
-      </div>
-    )
-  }
-
-  if (results && results.hits.length === 0) {
+  if (status === "idle" && results && results.hits.length === 0) {
     return (
       <div className="py-12 text-center">
         <p className="text-sm text-slate-700">

--- a/components/Search.tsx
+++ b/components/Search.tsx
@@ -59,9 +59,11 @@ function GroupedHits() {
     )
   }, [items])
 
-  if (status === "idle") {
-    stableGroupsRef.current = sortedGroups
-  }
+  React.useEffect(() => {
+    if (status === "idle") {
+      stableGroupsRef.current = sortedGroups
+    }
+  }, [status, sortedGroups])
 
   const hasStableResults = stableGroupsRef.current.length > 0
   const displayGroups =

--- a/components/Search.tsx
+++ b/components/Search.tsx
@@ -43,23 +43,32 @@ function getTypeOrder(type: string): number {
 
 function GroupedHits() {
   const { items } = useHits<SearchDocument>()
+  const { status } = useInstantSearch()
 
-  // Group hits by type
-  const grouped = items.reduce<Record<string, SearchHit[]>>((acc, hit) => {
-    const type = hit.type ?? "other"
-    if (!acc[type]) acc[type] = []
-    acc[type].push(hit)
-    return acc
-  }, {})
+  const stableGroupsRef = React.useRef<[string, SearchHit[]][]>([])
 
-  // Sort groups by defined order
-  const sortedGroups = Object.entries(grouped).sort(
-    ([a], [b]) => getTypeOrder(a) - getTypeOrder(b)
-  )
+  const sortedGroups = React.useMemo(() => {
+    const grouped = items.reduce<Record<string, SearchHit[]>>((acc, hit) => {
+      const type = hit.type ?? "other"
+      if (!acc[type]) acc[type] = []
+      acc[type].push(hit)
+      return acc
+    }, {})
+    return Object.entries(grouped).sort(
+      ([a], [b]) => getTypeOrder(a) - getTypeOrder(b)
+    )
+  }, [items])
+
+  if (status === "idle") {
+    stableGroupsRef.current = sortedGroups
+  }
+
+  const displayGroups =
+    status === "idle" ? sortedGroups : stableGroupsRef.current
 
   return (
     <div className="space-y-2">
-      {sortedGroups.map(([type, hits]) => (
+      {displayGroups.map(([type, hits]) => (
         <div key={type}>
           {/* Section header */}
           <div className="bg-white px-4 py-2">
@@ -67,7 +76,6 @@ function GroupedHits() {
               {getTypeLabel(type)}
             </span>
           </div>
-
           {/* Hits in this group */}
           <ul className="space-y-1">
             {hits.map((hit) => (
@@ -83,7 +91,7 @@ function GroupedHits() {
 }
 
 function SearchResults() {
-  const { results, indexUiState } = useInstantSearch()
+  const { results, indexUiState, status } = useInstantSearch()
   const hasQuery = indexUiState.query && indexUiState.query.length > 0
 
   if (!hasQuery) {
@@ -94,7 +102,7 @@ function SearchResults() {
     )
   }
 
-  if (hasQuery && !results) {
+  if (hasQuery && status === "stalled") {
     return (
       <div className="py-12 text-center">
         <p className="text-sm text-slate-700">Loading results...</p>


### PR DESCRIPTION
closes #559

In main, the unordered & unsorted hits would flash until the new hits were finished sorting/ordering.

I added a cache so that old results stay in the viewport until Algolia's status returns `idle`. Once I did that, there was still one edge-case where there would be a flash of an EMPTY div in the view: when the query starts as empty, and the user types a new query that they haven't typed before. In **only** this case, we show "Loading...".

So we still aren't using `status === loading` as a general loading indicator. We are using it as a fallback when there's nothing else to show. Once the first results are cached in stableGroupsRef, subsequent searches will always hold the previous results during "loading" instead of hitting this branch.

Don't mind the shown bug at 24 seconds...... new pr for that one

https://github.com/user-attachments/assets/583c25b3-38e3-4bee-8a23-17e5209eb957

