### PR TITLE
style: wrapped section heading has text center

### DIFF
--- a/components/ContentSection.tsx
+++ b/components/ContentSection.tsx
@@ -102,8 +102,11 @@ export function ContentTitle({
     <>
       {bars && <CCVBars />}
       <h2
-        className={cn("pb-2 tracking-tighter", icon ? "flex" : "", className)}
-        aria-label={title}
+        className={cn(
+          "pb-2 text-center tracking-tighter",
+          icon ? "flex" : "",
+          className
+        )}
         {...props}
       >
         {icon && (

--- a/components/SectionHeader.tsx
+++ b/components/SectionHeader.tsx
@@ -1,6 +1,10 @@
-import React from "react"
-import { CCVBars } from "@/components/assets/CCVBars"
+import {
+  ContentHeader,
+  ContentTitle,
+  ContentSubHeader,
+} from "@/components/ContentSection"
 import { cn } from "@/lib/utils"
+import React from "react"
 
 interface SectionHeaderProps {
   title: string
@@ -22,29 +26,22 @@ export function SectionHeader({
   titleClassName,
 }: SectionHeaderProps) {
   return (
-    <div
+    <ContentHeader
       className={cn(
-        `not-prose flex flex-col ${align === "center" ? "items-center" : "items-center lg:items-start"}`,
+        "not-prose",
+        align === "center" ? "items-center" : "items-center lg:items-start",
         className
       )}
+      data-align={align}
     >
-      {bars && <CCVBars />}
-      <h2
-        className={cn(
-          "pb-2 tracking-tighter",
-          icon ? "flex" : "",
-          titleClassName
-        )}
+      <ContentTitle
+        title={title}
+        bars={bars}
+        icon={icon}
+        className={titleClassName}
         aria-label={title}
-      >
-        {icon && (
-          <span className="mr-3" aria-hidden="true">
-            {icon}
-          </span>
-        )}
-        {title}
-      </h2>
-      {subHeader && <div className="space-y-6 pt-4">{subHeader}</div>}
-    </div>
+      />
+      {subHeader && <ContentSubHeader>{subHeader}</ContentSubHeader>}
+    </ContentHeader>
   )
 }


### PR DESCRIPTION
closes #571

Old:
<img width="306" height="146" alt="Screenshot 2026-05-05 at 12 59 24 PM" src="https://github.com/user-attachments/assets/85db8cec-3665-4346-a431-74cd25ef7d6c" />

New:
<img width="295" height="208" alt="Screenshot 2026-05-05 at 12 59 43 PM" src="https://github.com/user-attachments/assets/1b397ae1-845e-4150-8139-9b49059a8464" />
