### PR TITLE
feat: redirect to us from about

### DIFF
--- a/app/about/route.ts
+++ b/app/about/route.ts
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation"
+
+export function GET() {
+  redirect("/about/us")
+}


### PR DESCRIPTION
When users attempt to route to `/about` we now send them to `about/us` :D

Per @yangliu2009 - 

> Thank you for looking into the issue, Heather. I’d actually recommend not setting up redirects at all. Instead, we can just inform users that the CCV website has migrated and provide the new URLs. This way, we avoid the technical debt of maintaining the old URLs indefinitely. Just my 2c.