### PR TITLE
fix: reference correct docs link

### DIFF
--- a/content/routes/services/classroom.mdx
+++ b/content/routes/services/classroom.mdx
@@ -17,7 +17,7 @@ CCV provides access to HPC resources for classes, workshops, demonstrations, and
 - Oscar is a shared resource, so access nodes and speed cannot be guaranteed.
 
 <ButtonGroup>
-  <Button href="https://docs.ccv.brown.edu/oscar/account-types">
+  <Button href="https://docs.ccv.brown.edu/oscar/student-accounts">
     Learn More
   </Button>
   <Button href="/about/help#contact-us">


### PR DESCRIPTION
Updates the Classroom Support page with a link to the user doc page!

closes #578 