### PR TITLE
feat: Give title metadata to all pages

### DIFF
--- a/src/app/about/careers/page.tsx
+++ b/src/app/about/careers/page.tsx
@@ -7,18 +7,20 @@ import { CareerData } from "@/components/CareerData"
 import { getMDXMetadata } from "@/utils/mdx"
 import type { Metadata } from "next"
 
+const frontMatter = getMDXMetadata("src/content/routes/about/careers.mdx")
+
 export const metadata: Metadata = {
-  title: "Careers",
+  title: frontMatter.title,
+  description: frontMatter.description,
 }
 
 export default async function Careers() {
-  const metadata = getMDXMetadata("src/content/routes/about/careers.mdx")
   return (
     <>
       <Hero
-        image={metadata.image}
-        title={metadata.title}
-        description={metadata.description}
+        image={frontMatter.image}
+        title={frontMatter.title}
+        description={frontMatter.description}
       >
         <ButtonLink href="/about/help#contact-us" variant="primary_filled">
           Contact Us

--- a/src/app/about/careers/page.tsx
+++ b/src/app/about/careers/page.tsx
@@ -5,6 +5,11 @@ import { ButtonLink } from "@/components/button/ButtonLink"
 import CareersContent from "@/content/routes/about/careers.mdx"
 import { CareerData } from "@/components/CareerData"
 import { getMDXMetadata } from "@/utils/mdx"
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Careers",
+}
 
 export default async function Careers() {
   const metadata = getMDXMetadata("src/content/routes/about/careers.mdx")

--- a/src/app/about/grant-and-publication-materials/page.tsx
+++ b/src/app/about/grant-and-publication-materials/page.tsx
@@ -4,20 +4,20 @@ import GrantAndPublicationMaterialsContent from "@/content/routes/about/grant-an
 import { getMDXMetadata } from "@/utils/mdx"
 import type { Metadata } from "next"
 
+const frontMatter = getMDXMetadata(
+  "src/content/routes/about/grant-and-publication-materials.mdx"
+)
 export const metadata: Metadata = {
-  title: "Grant and Publication Materials",
+  title: frontMatter.title,
+  description: frontMatter.description,
 }
 export default async function PublicationAndGrantMaterials() {
-  const metadata = getMDXMetadata(
-    "src/content/routes/about/grant-and-publication-materials.mdx"
-  )
-
   return (
     <>
       <Hero
-        image={metadata.image}
-        title={metadata.title}
-        description={metadata.description}
+        image={frontMatter.image}
+        title={frontMatter.title}
+        description={frontMatter.description}
       />
       <GrantAndPublicationMaterialsContent />
     </>

--- a/src/app/about/grant-and-publication-materials/page.tsx
+++ b/src/app/about/grant-and-publication-materials/page.tsx
@@ -2,7 +2,11 @@ import React from "react"
 import { Hero } from "@/components/Hero"
 import GrantAndPublicationMaterialsContent from "@/content/routes/about/grant-and-publication-materials.mdx"
 import { getMDXMetadata } from "@/utils/mdx"
+import type { Metadata } from "next"
 
+export const metadata: Metadata = {
+  title: "Grant and Publication Materials",
+}
 export default async function PublicationAndGrantMaterials() {
   const metadata = getMDXMetadata(
     "src/content/routes/about/grant-and-publication-materials.mdx"

--- a/src/app/about/help/page.tsx
+++ b/src/app/about/help/page.tsx
@@ -4,18 +4,19 @@ import { getMDXMetadata } from "@/utils/mdx"
 import { Hero } from "@/components/Hero"
 import type { Metadata } from "next"
 
+const frontMatter = getMDXMetadata("src/content/routes/about/help.mdx")
+
 export const metadata: Metadata = {
-  title: "Help",
+  title: frontMatter.title,
+  description: frontMatter.description,
 }
 export default async function ContactUs() {
-  const metadata = getMDXMetadata("src/content/routes/about/help.mdx")
-
   return (
     <>
       <Hero
-        image={metadata.image}
-        title={metadata.title}
-        description={metadata.description}
+        image={frontMatter.image}
+        title={frontMatter.title}
+        description={frontMatter.description}
       />
       <ContactContent />
     </>

--- a/src/app/about/help/page.tsx
+++ b/src/app/about/help/page.tsx
@@ -2,7 +2,11 @@ import React from "react"
 import ContactContent from "@/content/routes/about/help.mdx"
 import { getMDXMetadata } from "@/utils/mdx"
 import { Hero } from "@/components/Hero"
+import type { Metadata } from "next"
 
+export const metadata: Metadata = {
+  title: "Help",
+}
 export default async function ContactUs() {
   const metadata = getMDXMetadata("src/content/routes/about/help.mdx")
 

--- a/src/app/about/us/page.tsx
+++ b/src/app/about/us/page.tsx
@@ -4,18 +4,19 @@ import AboutUsContent from "@/content/routes/about/us.mdx"
 import { getMDXMetadata } from "@/utils/mdx"
 import type { Metadata } from "next"
 
+const frontMatter = getMDXMetadata("src/content/routes/about/us.mdx")
+
 export const metadata: Metadata = {
-  title: "About Us",
+  title: frontMatter.title,
+  description: frontMatter.description,
 }
 export default async function AboutUs() {
-  const metadata = getMDXMetadata("src/content/routes/about/us.mdx")
-
   return (
     <>
       <Hero
-        image={metadata.image}
-        title={metadata.title}
-        description={metadata.description}
+        image={frontMatter.image}
+        title={frontMatter.title}
+        description={frontMatter.description}
       />
       <AboutUsContent />
     </>

--- a/src/app/about/us/page.tsx
+++ b/src/app/about/us/page.tsx
@@ -2,7 +2,11 @@ import React from "react"
 import { Hero } from "@/components/Hero"
 import AboutUsContent from "@/content/routes/about/us.mdx"
 import { getMDXMetadata } from "@/utils/mdx"
+import type { Metadata } from "next"
 
+export const metadata: Metadata = {
+  title: "About Us",
+}
 export default async function AboutUs() {
   const metadata = getMDXMetadata("src/content/routes/about/us.mdx")
 

--- a/src/app/ai/ai-oscar/page.tsx
+++ b/src/app/ai/ai-oscar/page.tsx
@@ -3,15 +3,16 @@ import AIOscarContent from "@/content/routes/ai/ai-oscar.mdx"
 import { getMDXMetadata } from "@/utils/mdx"
 import type { Metadata } from "next"
 
+const frontMatter = getMDXMetadata("src/content/routes/ai/ai-oscar.mdx")
+
 export const metadata: Metadata = {
-  title: "AI on Oscar",
+  title: frontMatter.title,
+  description: frontMatter.description,
 }
 export default function AIOscar() {
-  const metadata = getMDXMetadata("src/content/routes/ai/ai-oscar.mdx")
-
   return (
     <>
-      <Hero title={metadata.title} description={metadata.description} />
+      <Hero title={frontMatter.title} description={frontMatter.description} />
       <AIOscarContent />
     </>
   )

--- a/src/app/ai/ai-oscar/page.tsx
+++ b/src/app/ai/ai-oscar/page.tsx
@@ -1,7 +1,11 @@
 import { Hero } from "@/components/Hero"
 import AIOscarContent from "@/content/routes/ai/ai-oscar.mdx"
 import { getMDXMetadata } from "@/utils/mdx"
+import type { Metadata } from "next"
 
+export const metadata: Metadata = {
+  title: "AI on Oscar",
+}
 export default function AIOscar() {
   const metadata = getMDXMetadata("src/content/routes/ai/ai-oscar.mdx")
 

--- a/src/app/ai/ai-tools/page.tsx
+++ b/src/app/ai/ai-tools/page.tsx
@@ -4,16 +4,16 @@ import AIToolsContent from "@/content/routes/ai/ai-tools.mdx"
 import { getMDXMetadata } from "@/utils/mdx"
 import type { Metadata } from "next"
 
+const frontMatter = getMDXMetadata("src/content/routes/ai/ai-tools.mdx")
+
 export const metadata: Metadata = {
-  title: "AI Tools",
+  title: frontMatter.title,
+  description: frontMatter.description,
 }
-
 export default function AITools() {
-  const metadata = getMDXMetadata("src/content/routes/ai/ai-tools.mdx")
-
   return (
     <>
-      <Hero title={metadata.title} description={metadata.description}>
+      <Hero title={frontMatter.title} description={frontMatter.description}>
         <ButtonLink
           variant="primary_filled"
           size="lg"

--- a/src/app/ai/ai-tools/page.tsx
+++ b/src/app/ai/ai-tools/page.tsx
@@ -2,6 +2,11 @@ import { Hero } from "@/components/Hero"
 import { ButtonLink } from "@/components/button/ButtonLink"
 import AIToolsContent from "@/content/routes/ai/ai-tools.mdx"
 import { getMDXMetadata } from "@/utils/mdx"
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "AI Tools",
+}
 
 export default function AITools() {
   const metadata = getMDXMetadata("src/content/routes/ai/ai-tools.mdx")

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import { Inter, Source_Sans_3, Source_Serif_4 } from "next/font/google"
 import "@/app/globals.css"
 import { ReactNode } from "react"
+import type { Metadata } from "next"
 import { BrownBanner } from "@/components/BrownBanner"
 import { Navbar } from "@/components/navbar/Navbar"
 import { Footer } from "@/components/Footer"
@@ -35,8 +36,11 @@ const sourceSerif = Source_Serif_4({
   display: "swap",
 })
 
-export const metadata = {
-  title: "Center for Computation & Visualization",
+export const metadata: Metadata = {
+  title: {
+    template: "%s | Center for Computation & Visualization",
+    default: "Center for Computation & Visualization",
+  },
   description:
     "Advancing computational research with scientific and computing expertise at Brown University.",
   icons: {
@@ -64,7 +68,6 @@ export default async function RootLayoutWrapper({
     >
       <head>
         <link rel="icon" href="/favicon.ico" />
-        <title>{metadata.title}</title>
       </head>
       <body className={`${inter.className}`}>
         <Link

--- a/src/app/mdx-editing-guide/page.tsx
+++ b/src/app/mdx-editing-guide/page.tsx
@@ -1,6 +1,11 @@
 import { Hero } from "@/components/Hero"
 import MDXEditingGuideContent from "@/content/routes/mdx-editing-guide.mdx"
 import { getMDXMetadata } from "@/utils/mdx"
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "MDX Editing Guide",
+}
 
 export default function Page() {
   const metadata = getMDXMetadata("src/content/routes/mdx-editing-guide.mdx")

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,7 +1,11 @@
 import React from "react"
 import { Hero } from "@/components/Hero"
 import { ButtonLink } from "@/components/button/ButtonLink"
+import type { Metadata } from "next"
 
+export const metadata: Metadata = {
+  title: "404 - Page Not Found",
+}
 export default function NotFound() {
   return (
     <>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -16,8 +16,6 @@ import {
 } from "@/components/ContentSection"
 import { FaCalendarAlt } from "react-icons/fa"
 import { getMDXMetadata } from "@/utils/mdx"
-import { CopyableText } from "@/components/CopyableText"
-import { Link } from "@/components/Link"
 
 export default async function Home() {
   // Load featured carousel data from YAML

--- a/src/app/services/classroom/page.tsx
+++ b/src/app/services/classroom/page.tsx
@@ -5,6 +5,11 @@ import { FeaturedCarousel } from "@/components/carousel/FeaturedCarousel"
 import classroomCarousel from "@/content/data/classroom-carousel.json"
 import { StyledCarouselItem } from "@/components/carousel/StyledCarousel"
 import { ContentSection } from "@/components/ContentSection"
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Classroom Support",
+}
 
 export default async function ClassroomSupport() {
   const metadata = getMDXMetadata("src/content/routes/services/classroom.mdx")

--- a/src/app/services/classroom/page.tsx
+++ b/src/app/services/classroom/page.tsx
@@ -7,17 +7,19 @@ import { StyledCarouselItem } from "@/components/carousel/StyledCarousel"
 import { ContentSection } from "@/components/ContentSection"
 import type { Metadata } from "next"
 
+const frontMatter = getMDXMetadata("src/content/routes/services/classroom.mdx")
+
 export const metadata: Metadata = {
-  title: "Classroom Support",
+  title: frontMatter.title,
+  description: frontMatter.description,
 }
 
 export default async function ClassroomSupport() {
-  const metadata = getMDXMetadata("src/content/routes/services/classroom.mdx")
   // @ts-ignore
   const typedClassroomData = classroomCarousel as const as StyledCarouselItem[]
   return (
     <>
-      <Hero title={metadata.title} description={metadata.description} />
+      <Hero title={frontMatter.title} description={frontMatter.description} />
       <ContentSection
         title="In-Class Tutorials"
         className="px-none bg-neutral-50"

--- a/src/app/services/department-support/page.tsx
+++ b/src/app/services/department-support/page.tsx
@@ -3,18 +3,19 @@ import DepartmentSupportContent from "@/content/routes/services/department-suppo
 import { getMDXMetadata } from "@/utils/mdx"
 import type { Metadata } from "next"
 
+const frontMatter = getMDXMetadata(
+  "src/content/routes/services/department-support.mdx"
+)
+
 export const metadata: Metadata = {
-  title: "Department Support",
+  title: frontMatter.title,
+  description: frontMatter.description,
 }
 
 export default function DepartmentSupport() {
-  const metadata = getMDXMetadata(
-    "src/content/routes/services/department-support.mdx"
-  )
-
   return (
     <>
-      <Hero title={metadata.title} description={metadata.description} />
+      <Hero title={frontMatter.title} description={frontMatter.description} />
       <DepartmentSupportContent />
     </>
   )

--- a/src/app/services/department-support/page.tsx
+++ b/src/app/services/department-support/page.tsx
@@ -1,6 +1,11 @@
 import { Hero } from "@/components/Hero"
 import DepartmentSupportContent from "@/content/routes/services/department-support.mdx"
 import { getMDXMetadata } from "@/utils/mdx"
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Department Support",
+}
 
 export default function DepartmentSupport() {
   const metadata = getMDXMetadata(

--- a/src/app/services/file-storage-and-transfer/page.tsx
+++ b/src/app/services/file-storage-and-transfer/page.tsx
@@ -9,18 +9,18 @@ import Icon from "@/components/ui/RenderIcon"
 import { TABLE_VISIBILITY } from "@/styles/visibility"
 import type { Metadata } from "next"
 
+const frontMatter = getMDXMetadata(
+  "src/content/routes/services/file-storage-and-transfer.mdx"
+)
 export const metadata: Metadata = {
-  title: "File Storage and Transfer",
+  title: frontMatter.title,
+  description: frontMatter.description,
 }
 
 export default async function CompareStorageOptions() {
-  const metadata = getMDXMetadata(
-    "src/content/routes/services/file-storage-and-transfer.mdx"
-  )
-
   return (
     <>
-      <Hero title={metadata.title} description={metadata.description}>
+      <Hero title={frontMatter.title} description={frontMatter.description}>
         <ButtonLink
           variant="secondary_filled"
           size="lg"

--- a/src/app/services/file-storage-and-transfer/page.tsx
+++ b/src/app/services/file-storage-and-transfer/page.tsx
@@ -7,6 +7,11 @@ import { ButtonLink } from "@/components/button/ButtonLink"
 import { ScrollButton } from "@/components/button/ScrollButton"
 import Icon from "@/components/ui/RenderIcon"
 import { TABLE_VISIBILITY } from "@/styles/visibility"
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "File Storage and Transfer",
+}
 
 export default async function CompareStorageOptions() {
   const metadata = getMDXMetadata(

--- a/src/app/services/oscar/page.tsx
+++ b/src/app/services/oscar/page.tsx
@@ -4,16 +4,17 @@ import { getMDXMetadata } from "@/utils/mdx"
 import { ButtonLink } from "@/components/button/ButtonLink"
 import type { Metadata } from "next"
 
+const frontMatter = getMDXMetadata("src/content/routes/services/oscar.mdx")
+
 export const metadata: Metadata = {
-  title: "Oscar",
+  title: frontMatter.title,
+  description: frontMatter.description,
 }
 
 export default async function Oscar() {
-  const metadata = getMDXMetadata("src/content/routes/services/oscar.mdx")
-
   return (
     <>
-      <Hero title={metadata.title} description={metadata.description}>
+      <Hero title={frontMatter.title} description={frontMatter.description}>
         <ButtonLink
           variant="primary_filled"
           size="lg"

--- a/src/app/services/oscar/page.tsx
+++ b/src/app/services/oscar/page.tsx
@@ -2,6 +2,11 @@ import { Hero } from "@/components/Hero"
 import OscarContent from "@/content/routes/services/oscar.mdx"
 import { getMDXMetadata } from "@/utils/mdx"
 import { ButtonLink } from "@/components/button/ButtonLink"
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Oscar",
+}
 
 export default async function Oscar() {
   const metadata = getMDXMetadata("src/content/routes/services/oscar.mdx")

--- a/src/app/services/project-consulting/page.tsx
+++ b/src/app/services/project-consulting/page.tsx
@@ -4,21 +4,22 @@ import ProjectConsultingContent from "@/content/routes/services/project-consulti
 import { getMDXMetadata } from "@/utils/mdx"
 import type { Metadata } from "next"
 
+const frontMatter = getMDXMetadata(
+  "src/content/routes/services/project-consulting.mdx"
+)
+
 export const metadata: Metadata = {
-  title: "Project Consulting",
+  title: frontMatter.title,
+  description: frontMatter.description,
 }
 
 export default function ProjectConsulting() {
-  const metadata = getMDXMetadata(
-    "src/content/routes/services/project-consulting.mdx"
-  )
-
   return (
     <>
-      <Hero title={metadata.title} description={metadata.description}>
+      <Hero title={frontMatter.title} description={frontMatter.description}>
         <div className="flex flex-col items-start">
           <div className="flex w-full flex-col flex-wrap items-start gap-4 xl:flex-row">
-            {metadata.links.map((link: any, index: number) => (
+            {frontMatter.links.map((link: any, index: number) => (
               <ButtonLink
                 key={index}
                 variant="primary_filled"

--- a/src/app/services/project-consulting/page.tsx
+++ b/src/app/services/project-consulting/page.tsx
@@ -2,6 +2,11 @@ import { Hero } from "@/components/Hero"
 import { ButtonLink } from "@/components/button/ButtonLink"
 import ProjectConsultingContent from "@/content/routes/services/project-consulting.mdx"
 import { getMDXMetadata } from "@/utils/mdx"
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Project Consulting",
+}
 
 export default function ProjectConsulting() {
   const metadata = getMDXMetadata(

--- a/src/app/services/rates/page.tsx
+++ b/src/app/services/rates/page.tsx
@@ -3,16 +3,17 @@ import RatesContent from "@/content/routes/services/rates.mdx"
 import { getMDXMetadata } from "@/utils/mdx"
 import type { Metadata } from "next"
 
+const frontMatter = getMDXMetadata("src/content/routes/services/rates.mdx")
+
 export const metadata: Metadata = {
-  title: "Rates",
+  title: frontMatter.title,
+  description: frontMatter.description,
 }
 
 export default async function Rates() {
-  const metadata = getMDXMetadata("src/content/routes/services/rates.mdx")
-
   return (
     <>
-      <Hero title={metadata.title} description={metadata.description} />
+      <Hero title={frontMatter.title} description={frontMatter.description} />
       <RatesContent />
     </>
   )

--- a/src/app/services/rates/page.tsx
+++ b/src/app/services/rates/page.tsx
@@ -1,6 +1,11 @@
 import { Hero } from "@/components/Hero"
 import RatesContent from "@/content/routes/services/rates.mdx"
 import { getMDXMetadata } from "@/utils/mdx"
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Rates",
+}
 
 export default async function Rates() {
   const metadata = getMDXMetadata("src/content/routes/services/rates.mdx")

--- a/src/app/services/stronghold/page.tsx
+++ b/src/app/services/stronghold/page.tsx
@@ -4,16 +4,17 @@ import { getMDXMetadata } from "@/utils/mdx"
 import { ButtonLink } from "@/components/button/ButtonLink"
 import type { Metadata } from "next"
 
+const frontMatter = getMDXMetadata("src/content/routes/services/stronghold.mdx")
+
 export const metadata: Metadata = {
-  title: "Stronghold",
+  title: frontMatter.title,
+  description: frontMatter.description,
 }
 
 export default function Stronghold() {
-  const metadata = getMDXMetadata("src/content/routes/services/stronghold.mdx")
-
   return (
     <>
-      <Hero title={metadata.title} description={metadata.description}>
+      <Hero title={frontMatter.title} description={frontMatter.description}>
         <ButtonLink
           variant="primary_filled"
           size="lg"

--- a/src/app/services/stronghold/page.tsx
+++ b/src/app/services/stronghold/page.tsx
@@ -2,6 +2,11 @@ import { Hero } from "@/components/Hero"
 import StrongholdContent from "@/content/routes/services/stronghold.mdx"
 import { getMDXMetadata } from "@/utils/mdx"
 import { ButtonLink } from "@/components/button/ButtonLink"
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Stronghold",
+}
 
 export default function Stronghold() {
   const metadata = getMDXMetadata("src/content/routes/services/stronghold.mdx")

--- a/src/app/services/virtual-machine-hosting/page.tsx
+++ b/src/app/services/virtual-machine-hosting/page.tsx
@@ -1,8 +1,11 @@
 import { Hero } from "@/components/Hero"
 import VirtualMachineContent from "@/content/routes/services/virtual-machine-hosting.mdx"
 import { getMDXMetadata } from "@/utils/mdx"
-import { ButtonLink } from "@/components/button/ButtonLink"
+import type { Metadata } from "next"
 
+export const metadata: Metadata = {
+  title: "Virtual Machine Hosting",
+}
 export default function VirtualMachineHosting() {
   const metadata = getMDXMetadata(
     "src/content/routes/services/virtual-machine-hosting.mdx"

--- a/src/app/services/virtual-machine-hosting/page.tsx
+++ b/src/app/services/virtual-machine-hosting/page.tsx
@@ -3,17 +3,19 @@ import VirtualMachineContent from "@/content/routes/services/virtual-machine-hos
 import { getMDXMetadata } from "@/utils/mdx"
 import type { Metadata } from "next"
 
-export const metadata: Metadata = {
-  title: "Virtual Machine Hosting",
-}
-export default function VirtualMachineHosting() {
-  const metadata = getMDXMetadata(
-    "src/content/routes/services/virtual-machine-hosting.mdx"
-  )
+const frontMatter = getMDXMetadata(
+  "src/content/routes/services/virtual-machine-hosting.mdx"
+)
 
+export const metadata: Metadata = {
+  title: frontMatter.title,
+  description: frontMatter.description,
+}
+
+export default function VirtualMachineHosting() {
   return (
     <>
-      <Hero title={metadata.title} description={metadata.description} />
+      <Hero title={frontMatter.title} description={frontMatter.description} />
       <VirtualMachineContent />
     </>
   )

--- a/src/app/services/workshops/page.tsx
+++ b/src/app/services/workshops/page.tsx
@@ -3,15 +3,16 @@ import UserSupportContent from "@/content/routes/services/workshops.mdx"
 import { getMDXMetadata } from "@/utils/mdx"
 import type { Metadata } from "next"
 
+const frontMatter = getMDXMetadata("src/content/routes/services/workshops.mdx")
+
 export const metadata: Metadata = {
-  title: "Workshops",
+  title: frontMatter.title,
+  description: frontMatter.description,
 }
 export default function UserSupport() {
-  const metadata = getMDXMetadata("src/content/routes/services/workshops.mdx")
-
   return (
     <>
-      <Hero title={metadata.title} description={metadata.description} />
+      <Hero title={frontMatter.title} description={frontMatter.description} />
       <UserSupportContent />
     </>
   )

--- a/src/app/services/workshops/page.tsx
+++ b/src/app/services/workshops/page.tsx
@@ -1,7 +1,11 @@
 import { Hero } from "@/components/Hero"
 import UserSupportContent from "@/content/routes/services/workshops.mdx"
 import { getMDXMetadata } from "@/utils/mdx"
+import type { Metadata } from "next"
 
+export const metadata: Metadata = {
+  title: "Workshops",
+}
 export default function UserSupport() {
   const metadata = getMDXMetadata("src/content/routes/services/workshops.mdx")
 


### PR DESCRIPTION
I pulled `metadata` out of the route's function so that I could grab the mdx frontmatter for the title/description if available. Defaults to "Center for Computation & Visualization" per the layout if there isn't a title defined.

I didn't include a title within the base route, but I could see an argument for specifying "Home | Center for Computation & Visualization"? The other pages display "{title} | Center for Computation & Visualization" so like "Rates | Center for Computation & Visualization"