### PR TITLE
style: canceled events

### DIFF
--- a/src/components/EventSection.tsx
+++ b/src/components/EventSection.tsx
@@ -8,22 +8,85 @@ import { StyledTabs } from "@/components/StyledTabs"
 import { Spinner } from "@/components/assets/Spinner"
 import { FaExclamationTriangle } from "react-icons/fa"
 
-export interface DataProps {
+// For number values that typically would correspond as boolean, the API returns 0/1 instead of true/false.
+export interface EventDataProps {
   id: number
-  is_all_day: boolean
-  date: string
-  date_utc: string
-  date2_utc: string
-  date_iso: string
-  date_time: string
+  gid: number
   title: string
-  description_long: string
   url: string
+
+  date: string
+  date_time: string
+  date_utc: string
+  date_iso: string
+  date_ts: number
+  tz_offset: string
+  timezone: string
+
+  date2_time: string
+  date2_utc: string
+  date2_iso: string
+  date2_ts: number
+  tz2_offset: string
+
+  is_all_day: boolean
+
+  repeats: string | null
+  repeats_until: string | null
+  repeats_start: string | null
+  repeats_end: string | null
+
+  is_starred: boolean | null
+  is_canceled: number
+  is_online: number
+
+  online_type: string | null
+  online_url: string | null
+  online_button_label: string | null
+  online_instructions: string | null
+
+  description: string | null
+  description_long: string | null
+  contact_info: string | null
+
+  cost: string | null
+
+  location: string | null
+  location_title: string | null
+  location_latitude: number | null
+  location_longitude: number | null
+  location_id: number | null
+
+  thumbnail: string | null
+  thumbnail_caption: string | null
+  thumbnail_alt: string | null
+
+  has_registration: boolean | null
+  registration_owner_email: string | null
+  has_wait_list: boolean | null
+  registration_limit: number | null
+  wait_list_limit: number | null
+
+  rsvp_total: number | null
+  rsvp_waitlist_total: number | null
+
+  event_types: string[] | null
+  event_types_audience: string[] | null
+  event_types_campus: string[] | null
+
+  tags: string[] | null
+  tags_starred: string[] | null
+  tags_global: string[] | null
+
+  last_editor: string
+  last_modified: number
+
+  group: string
 }
 
 export function EventSection(): JSX.Element {
-  const [futureDates, setFutureDates] = useState<DataProps[]>([])
-  const [pastDates, setPastDates] = useState<DataProps[]>([])
+  const [futureDates, setFutureDates] = useState<EventDataProps[]>([])
+  const [pastDates, setPastDates] = useState<EventDataProps[]>([])
   const [currentDate, setCurrentDate] = useState<Date | null>(null)
   const [today, setToday] = useState("")
   const [loading, setLoading] = useState(true)
@@ -88,6 +151,7 @@ export function EventSection(): JSX.Element {
   }
 
   const allEvents = pastDates.concat(futureDates)
+  console.log(allEvents)
 
   return (
     <div className="flex w-full flex-col gap-4 xl:flex-row xl:justify-between xl:gap-24">
@@ -138,7 +202,7 @@ export function EventSection(): JSX.Element {
  */
 async function fetchEventRanges(
   today: string
-): Promise<[DataProps[], DataProps[]]> {
+): Promise<[EventDataProps[], EventDataProps[]]> {
   const [past, future] = await Promise.all([
     getEventData("-2 months", today), // bounded past window
     getEventData(today), // future from today
@@ -169,7 +233,7 @@ async function getDscovData(startDate: string, endDate?: string) {
 
   const response = await fetch(url)
   const data = await response.json()
-  return data.filter((event: DataProps) =>
+  return data.filter((event: EventDataProps) =>
     event.title.toLowerCase().includes("dscov")
   )
 }
@@ -185,7 +249,7 @@ export async function getEventData(startDate: string, endDate?: string) {
   return combinedData
 }
 
-function compareDates(a: DataProps, b: DataProps): number {
+function compareDates(a: EventDataProps, b: EventDataProps): number {
   const timeA = new Date(a.date_iso ?? "").getTime()
   const timeB = new Date(b.date_iso ?? "").getTime()
 

--- a/src/components/EventSection.tsx
+++ b/src/components/EventSection.tsx
@@ -151,7 +151,6 @@ export function EventSection(): JSX.Element {
   }
 
   const allEvents = pastDates.concat(futureDates)
-  console.log(allEvents)
 
   return (
     <div className="flex w-full flex-col gap-4 xl:flex-row xl:justify-between xl:gap-24">

--- a/src/components/EventSection.tsx
+++ b/src/components/EventSection.tsx
@@ -8,7 +8,7 @@ import { StyledTabs } from "@/components/StyledTabs"
 import { Spinner } from "@/components/assets/Spinner"
 import { FaExclamationTriangle } from "react-icons/fa"
 
-// For number values that typically would correspond as boolean, the API returns 0/1 instead of true/false.
+// For number values that typically would correspond as boolean, the API returns 1/0 instead of true/false.
 export interface EventDataProps {
   id: number
   gid: number

--- a/src/components/calendar/CalendarMonth.tsx
+++ b/src/components/calendar/CalendarMonth.tsx
@@ -20,7 +20,7 @@ import {
   getWeeksInMonth,
 } from "date-fns"
 import { CalendarHeading } from "@/components/calendar/CalendarHeading"
-import { DataProps } from "@/components/EventSection"
+import { EventDataProps } from "@/components/EventSection"
 import { ButtonLink } from "@/components/button/ButtonLink"
 
 function classNames(...classes: (string | boolean | undefined)[]) {
@@ -87,7 +87,7 @@ export function CalendarMonth({ events, currentDate, today }: CalendarProps) {
   const generateEventsForCurrentDay = (day: Date, isMobile = false) => {
     let sameDayEvents = events.filter((event) => isSameDay(event.date_utc, day))
     const dayEvents = sameDayEvents.filter(
-      (item: DataProps, index: number, self: DataProps[]) =>
+      (item: EventDataProps, index: number, self: EventDataProps[]) =>
         item.id !== undefined &&
         index === self.findIndex((t) => t.id === item.id)
     )
@@ -95,7 +95,7 @@ export function CalendarMonth({ events, currentDate, today }: CalendarProps) {
       (event) => event.date_time !== undefined
     )
 
-    const formattedCalEvents = validDayEvents.map((event: DataProps) => {
+    const formattedCalEvents = validDayEvents.map((event: EventDataProps) => {
       return (
         <li key={self.crypto.randomUUID()}>
           <PopoverEvent
@@ -183,7 +183,7 @@ export function CalendarMonth({ events, currentDate, today }: CalendarProps) {
         isSameDay(event.date_utc, day.date)
       )
       const dayEvents = sameDayEvents.filter(
-        (item: DataProps, index: number, self: DataProps[]) =>
+        (item: EventDataProps, index: number, self: EventDataProps[]) =>
           item.id !== undefined &&
           index === self.findIndex((t) => t.id === item.id)
       )

--- a/src/components/calendar/CalendarMonth.tsx
+++ b/src/components/calendar/CalendarMonth.tsx
@@ -99,7 +99,7 @@ export function CalendarMonth({ events, currentDate, today }: CalendarProps) {
       return (
         <li key={self.crypto.randomUUID()}>
           <PopoverEvent
-            className="max-w-full border-l-2 border-sunglow-400 pl-2 text-left tracking-tight hover:bg-slate-100"
+            className={`max-w-full border-l-2 pl-2 text-left tracking-tight hover:bg-slate-100 ${event.is_canceled == 1 ? "border-red-university opacity-60" : "border-sunglow-400"}`}
             event={event}
           />
         </li>

--- a/src/components/calendar/CalendarWeekly.tsx
+++ b/src/components/calendar/CalendarWeekly.tsx
@@ -19,7 +19,7 @@ import {
 import { PopoverEvent } from "@/components/calendar/PopoverEvent"
 import { CalendarProps } from "@/types/calendar-types"
 import { CalendarHeading } from "@/components/calendar/CalendarHeading"
-import type { DataProps } from "@/components/EventSection"
+import type { EventDataProps } from "@/components/EventSection"
 
 export function CalendarWeekly({ events, currentDate, today }: CalendarProps) {
   const container = useRef<HTMLDivElement>(null)
@@ -74,7 +74,7 @@ export function CalendarWeekly({ events, currentDate, today }: CalendarProps) {
    */
   const getWeekEvents = (date: Date) => {
     const startDate = startOfWeek(date)
-    const weekEvents = (events as DataProps[]).filter((event) => {
+    const weekEvents = (events as EventDataProps[]).filter((event) => {
       const eventDate = new Date(event.date_utc)
       return (
         isAfter(eventDate, startDate) &&
@@ -91,8 +91,8 @@ export function CalendarWeekly({ events, currentDate, today }: CalendarProps) {
   /**
    * Groups all-day events by weekday index so each day column can stack events.
    */
-  const getAllDayByWeekday = (allDayEvents: DataProps[]) => {
-    const byDay: Record<number, DataProps[]> = {
+  const getAllDayByWeekday = (allDayEvents: EventDataProps[]) => {
+    const byDay: Record<number, EventDataProps[]> = {
       0: [],
       1: [],
       2: [],

--- a/src/components/calendar/CalendarWeekly.tsx
+++ b/src/components/calendar/CalendarWeekly.tsx
@@ -20,6 +20,7 @@ import { PopoverEvent } from "@/components/calendar/PopoverEvent"
 import { CalendarProps } from "@/types/calendar-types"
 import { CalendarHeading } from "@/components/calendar/CalendarHeading"
 import type { EventDataProps } from "@/components/EventSection"
+import { cn } from "@/utils/helper"
 
 export function CalendarWeekly({ events, currentDate, today }: CalendarProps) {
   const container = useRef<HTMLDivElement>(null)
@@ -192,7 +193,10 @@ export function CalendarWeekly({ events, currentDate, today }: CalendarProps) {
                     <div key={dayIndex} className="min-w-0 space-y-1">
                       {allDayByWeekday[dayIndex].map((event) => (
                         <PopoverEvent
-                          className="rounded-lg bg-sunglow-300 py-2 text-xs leading-tight hover:bg-sunglow-200"
+                          className={cn(
+                            "rounded-lg bg-sunglow-300 py-2 text-xs leading-tight hover:bg-sunglow-200",
+                            event.is_canceled == 1 ? "opacity-60" : ""
+                          )}
                           event={event}
                           key={self.crypto.randomUUID()}
                         />
@@ -289,7 +293,7 @@ export function CalendarWeekly({ events, currentDate, today }: CalendarProps) {
                       <PopoverEvent
                         className={`absolute inset-1 flex flex-col items-center rounded-lg bg-sunglow-300 p-2 text-xs leading-tight hover:bg-sunglow-200 ${
                           spanBlocks > 6 ? "gap-2" : ""
-                        }`}
+                        } ${event.is_canceled == 1 ? "opacity-60" : ""}`}
                         event={event}
                         includeTime
                       />

--- a/src/components/calendar/PopoverEvent.tsx
+++ b/src/components/calendar/PopoverEvent.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import type { DataProps } from "@/components/EventSection"
+import type { EventDataProps } from "@/components/EventSection"
 import {
   Popover,
   PopoverContent,
@@ -12,7 +12,7 @@ import { ArrowTopRightOnSquareIcon, ClockIcon } from "@heroicons/react/20/solid"
 import React from "react"
 
 interface PopoverEventProps {
-  event: DataProps
+  event: EventDataProps
   includeTime?: boolean
   className?: string
 }

--- a/src/components/calendar/UpcomingEvents.tsx
+++ b/src/components/calendar/UpcomingEvents.tsx
@@ -1,10 +1,10 @@
 import { JSX, Key } from "react"
-import { DataProps } from "@/components/EventSection"
+import { EventDataProps } from "@/components/EventSection"
 import { EventsCard } from "@/components/card/EventsCard"
 import React from "react"
 
 interface UpcomingEventsViewProps {
-  events: DataProps[]
+  events: EventDataProps[]
   limit?: number
 }
 
@@ -14,7 +14,10 @@ export function UpcomingEvents({ events, limit = 4 }: UpcomingEventsViewProps) {
   return (
     <div className="flex flex-wrap justify-center gap-6 lg:justify-end">
       {displayedEvents?.map(
-        (e: JSX.IntrinsicAttributes & DataProps, i: Key | null | undefined) => (
+        (
+          e: JSX.IntrinsicAttributes & EventDataProps,
+          i: Key | null | undefined
+        ) => (
           <React.Fragment key={i}>
             <EventsCard {...e} />
           </React.Fragment>

--- a/src/components/card/EventsCard.tsx
+++ b/src/components/card/EventsCard.tsx
@@ -3,7 +3,7 @@ import React from "react"
 import sanitizeHtml from "sanitize-html"
 
 import { StyledCard } from "@/components/card/StyledCard"
-import { DataProps } from "@/components/EventSection"
+import { EventDataProps } from "@/components/EventSection"
 import Icon from "@/components/ui/RenderIcon"
 import { Link } from "@/components/Link"
 
@@ -14,19 +14,26 @@ export function EventsCard({
   date,
   date_utc,
   is_all_day,
+  is_canceled,
   description_long,
-}: DataProps) {
-  const descriptionLong = sanitizeHtml(description_long, {
-    allowedTags: [],
-    allowedAttributes: {},
-  })
+}: EventDataProps) {
+  const descriptionLong = description_long
+    ? sanitizeHtml(description_long, {
+        allowedTags: [],
+        allowedAttributes: {},
+      })
+    : ""
   const dateTime = new Date(date_utc.replace(/-/g, "/"))
   const normalDate =
     new Intl.DateTimeFormat("en-US", { weekday: "long" }).format(dateTime) +
     ", " +
     date
   return (
-    <StyledCard title={title} size="sm">
+    <StyledCard
+      title={title}
+      size="sm"
+      className={is_canceled == 1 ? "opacity-60" : ""}
+    >
       <div className="space-y-2">
         <p className="font-semibold text-slate-900">{normalDate}</p>
         <div className="flex items-center gap-2 text-keppel-800">

--- a/src/components/card/StyledCard.tsx
+++ b/src/components/card/StyledCard.tsx
@@ -42,7 +42,7 @@ export function StyledCard({
   }
 
   const titleClassName = cn(
-    "flex text-lg items-center justify-center gap-4 border-b border-gray-300 py-4 text-center rounded-md text-black",
+    "flex text-lg items-center justify-center gap-4 border-b border-gray-300 py-4 text-center",
     headerColor ? headerColorClass[headerColor] : undefined
   )
   return (

--- a/src/types/calendar-types.ts
+++ b/src/types/calendar-types.ts
@@ -1,7 +1,7 @@
-import { DataProps } from "@/components/EventSection"
+import { EventDataProps } from "@/components/EventSection"
 
 export interface CalendarProps {
-  events: Array<DataProps>
+  events: Array<EventDataProps>
   currentDate: Date
   today: string
 }


### PR DESCRIPTION
Lowers the opacity for canceled events:

<img width="1724" height="791" alt="Screenshot 2026-06-02 at 3 04 56 PM" src="https://github.com/user-attachments/assets/2bec0b70-73df-4d5f-aaf4-67968722a32f" />
<img width="1717" height="742" alt="Screenshot 2026-06-02 at 3 02 45 PM" src="https://github.com/user-attachments/assets/b0e48642-3cbb-4160-a0e3-fdbfc56ffeae" />
<img width="1320" height="773" alt="Screenshot 2026-06-02 at 3 02 33 PM" src="https://github.com/user-attachments/assets/fc187aac-be96-4661-bfcd-600c1cb4b9b4" />

closes #613 
closes #612 