### PR TITLE
style: remove size label, aria label to extend title

### DIFF
--- a/src/content/routes/ai/ai-tools.mdx
+++ b/src/content/routes/ai/ai-tools.mdx
@@ -13,10 +13,10 @@ computational workflows, we have the resources and expertise to support your nee
 
 <Button
   variant="primary_filled"
-  size="md"
+  aria-label="CCV AI Tools Privacy Statement"
   href="https://docs.ccv.brown.edu/ai-tools/privacy-statement"
 >
-  CCV AI Tools Privacy Statement
+  Privacy Statement
 </Button>
 
   <CardGroup>


### PR DESCRIPTION
closes #592

Makes the privacy statement button NORMAL looking:

<img width="1611" height="318" alt="Screenshot 2026-06-02 at 3 15 02 PM" src="https://github.com/user-attachments/assets/13a6f8ef-d20c-4c1c-b142-a35b8e609ffb" />
