### PR TITLE
feat: remove delay from submenu appearing

### DIFF
--- a/src/components/navbar/Navbar.tsx
+++ b/src/components/navbar/Navbar.tsx
@@ -66,7 +66,10 @@ function DesktopLinks({ docsHref, helpHref }: DesktopLinksProps) {
  */
 function DesktopNavigation() {
   return (
-    <NavigationMenu.Root className="relative z-10 hidden w-full items-stretch justify-between lg:flex">
+    <NavigationMenu.Root
+      className="relative z-10 hidden w-full items-stretch justify-between lg:flex"
+      delayDuration={0}
+    >
       <NavigationMenu.List className="flex h-full items-center">
         {routes.map((section) => (
           <NavigationMenu.Item key={section.name}>


### PR DESCRIPTION
closes #577

Per @hollandjg, there is some frustration around the menu. If you hover, wait a bit, then click exactly when the submenu finishes opening, the click is interpreted as a toggle and the menu instantly closes.

That delay is 200ms by default. I changed it to be instant in this PR, but we can talk about what feels best.

